### PR TITLE
docs(typo): add .rules to flat config

### DIFF
--- a/docs/parsers/html.md
+++ b/docs/parsers/html.md
@@ -28,9 +28,9 @@ export default [
     },
     rules: {
       // enable all recommended rules to warn
-      ...eslintPluginReadableTailwind.configs.warning,
+      ...eslintPluginReadableTailwind.configs.warning.rules,
       // enable all recommended rules to error
-      ...eslintPluginReadableTailwind.configs.error,
+      ...eslintPluginReadableTailwind.configs.error.rules,
 
       // or configure rules individually
       "readable-tailwind/multiline": ["warn", { printWidth: 100 }]

--- a/docs/parsers/jsx.md
+++ b/docs/parsers/jsx.md
@@ -26,9 +26,9 @@ export default [
     },
     rules: {
       // enable all recommended rules to warn
-      ...eslintPluginReadableTailwind.configs.warning,
+      ...eslintPluginReadableTailwind.configs.warning.rules,
       // enable all recommended rules to error
-      ...eslintPluginReadableTailwind.configs.error,
+      ...eslintPluginReadableTailwind.configs.error.rules,
 
       // or configure rules individually
       "readable-tailwind/multiline": ["warn", { printWidth: 100 }]

--- a/docs/parsers/svelte.md
+++ b/docs/parsers/svelte.md
@@ -27,9 +27,9 @@ export default [
     },
     rules: {
       // enable all recommended rules to warn
-      ...eslintPluginReadableTailwind.configs.warning,
+      ...eslintPluginReadableTailwind.configs.warning.rules,
       // enable all recommended rules to error
-      ...eslintPluginReadableTailwind.configs.error,
+      ...eslintPluginReadableTailwind.configs.error.rules,
 
       // or configure rules individually
       "readable-tailwind/multiline": ["warn", { printWidth: 100 }]

--- a/docs/parsers/vue.md
+++ b/docs/parsers/vue.md
@@ -27,9 +27,9 @@ export default [
     },
     rules: {
       // enable all recommended rules to warn
-      ...eslintPluginReadableTailwind.configs.warning,
+      ...eslintPluginReadableTailwind.configs.warning.rules,
       // enable all recommended rules to error
-      ...eslintPluginReadableTailwind.configs.error,
+      ...eslintPluginReadableTailwind.configs.error.rules,
 
       // or configure rules individually
       "readable-tailwind/multiline": ["warn", { printWidth: 100 }]


### PR DESCRIPTION
Thank you for taking your time to create this plugin, I really appreciated.
Love the project!! 😍

Just fix the example usage on Flat config.
without `.rules` linter will throw an error.