### PR TITLE
fix: false positives when using `crlf`

### DIFF
--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -33,6 +33,16 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 <br/>
 
+- `lineBreakStyle`
+
+  The line break style.  
+  The style `windows` will use `\\r\\n` as line breaks and `unix` will use `\\n`.
+
+  **Type**: `"windows" | "unix"`
+  **Default**: `"unix"`
+
+<br/>
+
 - `printWidth`
 
   The maximum line length. Lines are wrapped appropriately to stay within this limit. The value `0` disables line wrapping by `printWidth`.

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -730,4 +730,32 @@ describe(tailwindMultiline.name, () => {
 
   });
 
+  it("should be possible to change the lineBreakStyle to windows", () => {
+
+    const dirty = " a b c d e f g h ";
+    const clean = "\r\n  a b c\r\n  d e f\r\n  g h\r\n";
+
+    expect(void lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            html: `<div class="${dirty}" />`,
+            htmlOutput: `<div class="${clean}" />`,
+            jsx: `const Test = () => <div class="${dirty}" />;`,
+            jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+            options: [{ classesPerLine: 3, indent: 2, lineBreakStyle: "windows" }],
+            svelte: `<div class="${dirty}" />`,
+            svelteOutput: `<div class="${clean}" />`,
+            vue: `<template><div class="${dirty}" /></template>`,
+            vueOutput: `<template><div class="${clean}" /></template>`
+          }
+        ]
+      }
+    )).toBeUndefined();
+
+  });
+
 });

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -26,6 +26,7 @@ export type Options = [
     classesPerLine?: number;
     group?: "emptyLine" | "never" | "newLine";
     indent?: number | "tab";
+    lineBreakStyle?: "unix" | "windows";
     printWidth?: number;
     trim?: boolean;
     variables?: Variables;
@@ -203,6 +204,12 @@ export const tailwindMultiline: ESLintRule<Options> = {
               type: "integer"
 
             },
+            lineBreakStyle: {
+              default: getOptions().lineBreakStyle,
+              description: "The line break style. The style `windows` will use `\\r\\n` as line breaks and `unix` will use `\\n`.",
+              enum: ["unix", "windows"],
+              type: "string"
+            },
             printWidth: {
               default: getOptions().printWidth,
               description: "The maximum line length. Lines are wrapped appropriately to stay within this limit. The value `0` disables line wrapping by `printWidth`.",
@@ -240,7 +247,7 @@ export const tailwindMultiline: ESLintRule<Options> = {
 
 function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
-  const { classesPerLine, group: groupSeparator, indent, printWidth } = getOptions(ctx);
+  const { classesPerLine, group: groupSeparator, indent, lineBreakStyle, printWidth } = getOptions(ctx);
 
   for(const literal of literals){
 
@@ -437,7 +444,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
     }
 
-    const fixedClasses = lines.toString();
+    const fixedClasses = lines.toString(lineBreakStyle);
 
     if(literal.raw === fixedClasses){
       continue;
@@ -476,6 +483,7 @@ function getOptions(ctx?: Rule.RuleContext) {
   const classAttributes = options.classAttributes ?? DEFAULT_CLASS_NAMES;
   const callees = options.callees ?? DEFAULT_CALLEE_NAMES;
   const variables = options.variables ?? DEFAULT_VARIABLE_NAMES;
+  const lineBreakStyle = options.lineBreakStyle ?? "unix";
 
   return {
     callees,
@@ -483,6 +491,7 @@ function getOptions(ctx?: Rule.RuleContext) {
     classesPerLine,
     group,
     indent,
+    lineBreakStyle,
     printWidth,
     variables
   };
@@ -525,10 +534,12 @@ class Lines {
     return this;
   }
 
-  public toString() {
+  public toString(lineBreakStyle: Options[0]["lineBreakStyle"] = "unix") {
+    const lineBreaks = lineBreakStyle === "unix" ? "\n" : "\r\n";
+
     return this.lines.map(
       line => line.toString()
-    ).join("\n");
+    ).join(lineBreaks);
   }
 }
 


### PR DESCRIPTION
closes #10 