### PR TITLE
fix: remove unnecessary trailing spaces in multiline strings

### DIFF
--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -253,7 +253,8 @@ function splitClassesKeepWhitespace(literal: Literal, allowMultiline: boolean): 
 
     if(whitespaceChunk){
       if(whitespaceChunk.includes("\n") && allowMultiline === true){
-        mixedChunks.push(whitespaceChunk);
+        const whitespaceWithoutLeadingSpaces = whitespaceChunk.replace(/^ +/, "");
+        mixedChunks.push(whitespaceWithoutLeadingSpaces);
       } else {
         if(!isFirstChunk && !isLastChunk ||
           literal.type === "TemplateLiteral" && literal.closingBraces && isFirstChunk && !isLastChunk ||


### PR DESCRIPTION
Example:

```tsx
// BAD
<div·class="
··a··
··b··
"·/>
```

```tsx
// GOOD
<div·class="
··a
··b
"·/>
```
