### PR TITLE
test: simplify testing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "streetsidesoftware.code-spell-checker",
-    "davidanson.vscode-markdownlint",
-    "dnek.auto-region-folder",
-    "Tobermory.es6-string-html"
+    "davidanson.vscode-markdownlint"
   ]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,13 @@
-export { default } from "@schoero/configs/eslint";
+import sharedConfig from "@schoero/configs/eslint";
+
+
+export default [
+  ...sharedConfig,
+  {
+    files: ["**/*.test.{js,jsx,cjs,mjs,ts,tsx}", "**/*.test-d.{ts,tsx}"],
+    rules: {
+      "eslint-plugin-stylistic-ts/quotes": ["warn", "double", { allowTemplateLiterals: true, avoidEscape: true }],
+      "eslint-plugin-vitest/expect-expect": "off"
+    }
+  }
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,8 @@ export default [
     files: ["**/*.test.{js,jsx,cjs,mjs,ts,tsx}", "**/*.test-d.{ts,tsx}"],
     rules: {
       "eslint-plugin-stylistic-ts/quotes": ["warn", "double", { allowTemplateLiterals: true, avoidEscape: true }],
+      "eslint-plugin-typescript/no-unnecessary-condition": "off",
+      "eslint-plugin-typescript/no-useless-template-literals": "off",
       "eslint-plugin-vitest/expect-expect": "off"
     }
   }

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -14,28 +14,28 @@ describe(tailwindMultiline.name, () => {
       {
         valid: [
           {
-            html: "<div class=\"\" />",
-            jsx: "<div class=\"\" />",
-            svelte: "<div class=\"\" />",
-            vue: "<template><div class=\"\" /></template>"
+            html: "<img class=\"\" />",
+            jsx: "<img class=\"\" />",
+            svelte: "<img class=\"\" />",
+            vue: "<template><img class=\"\" /></template>"
           },
           {
-            html: "<div class='' />",
-            jsx: "<div class='' />",
-            svelte: "<div class='' />",
-            vue: "<template><div class='' /></template>"
+            html: "<img class='' />",
+            jsx: "<img class='' />",
+            svelte: "<img class='' />",
+            vue: "<template><img class='' /></template>"
           },
           {
-            jsx: "<div class={\"\"} />",
-            svelte: "<div class={\"\"} />"
+            jsx: "<img class={\"\"} />",
+            svelte: "<img class={\"\"} />"
           },
           {
-            jsx: "<div class={''} />",
-            svelte: "<div class={''} />"
+            jsx: "<img class={''} />",
+            svelte: "<img class={''} />"
           },
           {
-            jsx: "<div class={``} />",
-            svelte: "<div class={``} />"
+            jsx: "<img class={``} />",
+            svelte: "<img class={``} />"
           }
         ]
       }
@@ -49,28 +49,28 @@ describe(tailwindMultiline.name, () => {
       {
         valid: [
           {
-            html: "<div class=\"a b c\" />",
-            jsx: "<div class=\"a b c\" />",
-            svelte: "<div class=\"a b c\" />",
-            vue: "<template><div class=\"a b c\" /></template>"
+            html: "<img class=\"a b c\" />",
+            jsx: "<img class=\"a b c\" />",
+            svelte: "<img class=\"a b c\" />",
+            vue: "<template><img class=\"a b c\" /></template>"
           },
           {
-            html: "<div class='a b c' />",
-            jsx: "<div class='a b c' />",
-            svelte: "<div class='a b c' />",
-            vue: "<template><div class='a b c' /></template>"
+            html: "<img class='a b c' />",
+            jsx: "<img class='a b c' />",
+            svelte: "<img class='a b c' />",
+            vue: "<template><img class='a b c' /></template>"
           },
           {
-            jsx: "<div class={\"a b c\"} />",
-            svelte: "<div class={\"a b c\"} />"
+            jsx: "<img class={\"a b c\"} />",
+            svelte: "<img class={\"a b c\"} />"
           },
           {
-            jsx: "<div class={'a b c'} />",
-            svelte: "<div class={'a b c'} />"
+            jsx: "<img class={'a b c'} />",
+            svelte: "<img class={'a b c'} />"
           },
           {
-            jsx: "<div class={`a b c`} />",
-            svelte: "<div class={`a b c`} />"
+            jsx: "<img class={`a b c`} />",
+            svelte: "<img class={`a b c`} />"
           }
         ]
       }
@@ -94,15 +94,15 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            html: `<div class="${dirty}" />`,
-            htmlOutput: `<div class="${clean}" />`,
-            jsx: `<div class={\`${dirty}\`} />`,
-            jsxOutput: `<div class={\`${clean}\`} />`,
+            html: `<img class="${dirty}" />`,
+            htmlOutput: `<img class="${clean}" />`,
+            jsx: `<img class={\`${dirty}\`} />`,
+            jsxOutput: `<img class={\`${clean}\`} />`,
             options: [{ printWidth: 60 }],
-            svelte: `<div class="${dirty}" />`,
-            svelteOutput: `<div class="${clean}" />`,
-            vue: `<template><div class="${dirty}" /></template>`,
-            vueOutput: `<template><div class="${clean}" /></template>`
+            svelte: `<img class="${dirty}" />`,
+            svelteOutput: `<img class="${clean}" />`,
+            vue: `<template><img class="${dirty}" /></template>`,
+            vueOutput: `<template><img class="${clean}" /></template>`
           }
         ]
       }
@@ -131,11 +131,11 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<div class={\`${incorrect}\`} />`,
-            jsxOutput: `<div class={\`${correct}\`} />`,
+            jsx: `<img class={\`${incorrect}\`} />`,
+            jsxOutput: `<img class={\`${correct}\`} />`,
             options: [{ classesPerLine: 3, group: "newLine", indent: 2 }],
-            svelte: `<div class={\`${incorrect}\`} />`,
-            svelteOutput: `<div class={\`${correct}\`} />`
+            svelte: `<img class={\`${incorrect}\`} />`,
+            svelteOutput: `<img class={\`${correct}\`} />`
           }
         ]
       }
@@ -159,15 +159,15 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            html: `<div class="${dirty}" />`,
-            htmlOutput: `<div class="${clean}" />`,
-            jsx: `<div class="${dirty}" />`,
-            jsxOutput: `<div class={\`${clean}\`} />`,
+            html: `<img class="${dirty}" />`,
+            htmlOutput: `<img class="${clean}" />`,
+            jsx: `<img class="${dirty}" />`,
+            jsxOutput: `<img class={\`${clean}\`} />`,
             options: [{ printWidth: 60 }],
-            svelte: `<div class="${dirty}" />`,
-            svelteOutput: `<div class="${clean}" />`,
-            vue: `<template><div class="${dirty}" /></template>`,
-            vueOutput: `<template><div class="${clean}" /></template>`
+            svelte: `<img class="${dirty}" />`,
+            svelteOutput: `<img class="${clean}" />`,
+            vue: `<template><img class="${dirty}" /></template>`,
+            vueOutput: `<template><img class="${clean}" /></template>`
           }
         ]
       }
@@ -181,11 +181,11 @@ describe(tailwindMultiline.name, () => {
       {
         valid: [
           {
-            html: "<div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
-            jsx: "<div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
+            html: "<img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
+            jsx: "<img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
             options: [{ printWidth: 0 }],
-            svelte: "<div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
-            vue: "<template><div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" /></template>"
+            svelte: "<img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
+            vue: "<template><img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" /></template>"
           }
         ]
       }
@@ -213,18 +213,18 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<div class={${dirtyDefined}} />`,
-            jsxOutput: `<div class={${cleanDefined}} />`,
+            jsx: `<img class={${dirtyDefined}} />`,
+            jsxOutput: `<img class={${cleanDefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={${dirtyDefined}} />`,
-            svelteOutput: `<div class={${cleanDefined}} />`
+            svelte: `<img class={${dirtyDefined}} />`,
+            svelteOutput: `<img class={${cleanDefined}} />`
           }
         ],
         valid: [
           {
-            jsx: `<div class={${dirtyUndefined}} />`,
+            jsx: `<img class={${dirtyUndefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={${dirtyUndefined}} />`
+            svelte: `<img class={${dirtyUndefined}} />`
           }
         ]
       }
@@ -237,18 +237,18 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<div class={${dirtyDefined}} />`,
-            jsxOutput: `<div class={${cleanDefined}} />`,
+            jsx: `<img class={${dirtyDefined}} />`,
+            jsxOutput: `<img class={${cleanDefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={${dirtyDefined}} />`,
-            svelteOutput: `<div class={${cleanDefined}} />`
+            svelte: `<img class={${dirtyDefined}} />`,
+            svelteOutput: `<img class={${cleanDefined}} />`
           }
         ],
         valid: [
           {
-            jsx: `<div class={${dirtyUndefined}} />`,
+            jsx: `<img class={${dirtyUndefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={${dirtyUndefined}} />`
+            svelte: `<img class={${dirtyUndefined}} />`
           }
         ]
       }
@@ -364,48 +364,48 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<div class="${singleLine}" />`,
-            jsxOutput: `<div class={\`${multiline}\`} />`,
+            jsx: `<img class="${singleLine}" />`,
+            jsxOutput: `<img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }]
           },
           {
             errors: 1,
-            jsx: `<div class='${singleLine}' />`,
-            jsxOutput: `<div class={\`${multiline}\`} />`,
+            jsx: `<img class='${singleLine}' />`,
+            jsxOutput: `<img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }]
           },
           {
             errors: 1,
-            jsx: `<div class={"${singleLine}"} />`,
-            jsxOutput: `<div class={\`${multiline}\`} />`,
+            jsx: `<img class={"${singleLine}"} />`,
+            jsxOutput: `<img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={"${singleLine}"} />`,
-            svelteOutput: `<div class={\`${multiline}\`} />`
+            svelte: `<img class={"${singleLine}"} />`,
+            svelteOutput: `<img class={\`${multiline}\`} />`
           },
           {
             errors: 1,
-            jsx: `<div class={'${singleLine}'} />`,
-            jsxOutput: `<div class={\`${multiline}\`} />`,
+            jsx: `<img class={'${singleLine}'} />`,
+            jsxOutput: `<img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={'${singleLine}'} />`,
-            svelteOutput: `<div class={\`${multiline}\`} />`
+            svelte: `<img class={'${singleLine}'} />`,
+            svelteOutput: `<img class={\`${multiline}\`} />`
           }
         ],
         valid: [
           {
-            jsx: `<div class={\`${multiline}\`} />`,
+            jsx: `<img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${multiline}\`} />`
+            svelte: `<img class={\`${multiline}\`} />`
           },
           {
-            html: `<div class="${multiline}" />`,
+            html: `<img class="${multiline}" />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class="${multiline}" />`
+            svelte: `<img class="${multiline}" />`
           },
           {
-            html: `<div class='${multiline}' />`,
+            html: `<img class='${multiline}' />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class='${multiline}' />`
+            svelte: `<img class='${multiline}' />`
           }
         ]
       }
@@ -427,51 +427,51 @@ describe(tailwindMultiline.name, () => {
       invalid: [
         {
           errors: 1,
-          html: `<div class="${singleLine}" />`,
-          htmlOutput: `<div class="${multiline}" />`,
-          jsx: `<div class="${singleLine}" />`,
-          jsxOutput: `<div class={\`${multiline}\`} />`,
+          html: `<img class="${singleLine}" />`,
+          htmlOutput: `<img class="${multiline}" />`,
+          jsx: `<img class="${singleLine}" />`,
+          jsxOutput: `<img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
-          svelte: `<div class="${singleLine}" />`,
-          svelteOutput: `<div class="${multiline}" />`,
-          vue: `<template><div class="${singleLine}" /></template>`,
-          vueOutput: `<template><div class="${multiline}" /></template>`
+          svelte: `<img class="${singleLine}" />`,
+          svelteOutput: `<img class="${multiline}" />`,
+          vue: `<template><img class="${singleLine}" /></template>`,
+          vueOutput: `<template><img class="${multiline}" /></template>`
         },
         {
           errors: 1,
-          html: `<div class='${singleLine}' />`,
-          htmlOutput: `<div class='${multiline}' />`,
-          jsx: `<div class='${singleLine}' />`,
-          jsxOutput: `<div class={\`${multiline}\`} />`,
+          html: `<img class='${singleLine}' />`,
+          htmlOutput: `<img class='${multiline}' />`,
+          jsx: `<img class='${singleLine}' />`,
+          jsxOutput: `<img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
-          svelte: `<div class='${singleLine}' />`,
-          svelteOutput: `<div class='${multiline}' />`,
-          vue: `<template><div class='${singleLine}' /></template>`,
-          vueOutput: `<template><div class='${multiline}' /></template>`
+          svelte: `<img class='${singleLine}' />`,
+          svelteOutput: `<img class='${multiline}' />`,
+          vue: `<template><img class='${singleLine}' /></template>`,
+          vueOutput: `<template><img class='${multiline}' /></template>`
         },
         {
           errors: 1,
-          jsx: `<div class={\`${singleLine}\`} />`,
-          jsxOutput: `<div class={\`${multiline}\`} />`,
+          jsx: `<img class={\`${singleLine}\`} />`,
+          jsxOutput: `<img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
-          svelte: `<div class={\`${singleLine}\`} />`,
-          svelteOutput: `<div class={\`${multiline}\`} />`
+          svelte: `<img class={\`${singleLine}\`} />`,
+          svelteOutput: `<img class={\`${multiline}\`} />`
         },
         {
           errors: 1,
-          jsx: `<div class={"${singleLine}"} />`,
-          jsxOutput: `<div class={\`${multiline}\`} />`,
+          jsx: `<img class={"${singleLine}"} />`,
+          jsxOutput: `<img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
-          svelte: `<div class={"${singleLine}"} />`,
-          svelteOutput: `<div class={\`${multiline}\`} />`
+          svelte: `<img class={"${singleLine}"} />`,
+          svelteOutput: `<img class={\`${multiline}\`} />`
         },
         {
           errors: 1,
-          jsx: `<div class={'${singleLine}'} />`,
-          jsxOutput: `<div class={\`${multiline}\`} />`,
+          jsx: `<img class={'${singleLine}'} />`,
+          jsxOutput: `<img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
-          svelte: `<div class={'${singleLine}'} />`,
-          svelteOutput: `<div class={\`${multiline}\`} />`
+          svelte: `<img class={'${singleLine}'} />`,
+          svelteOutput: `<img class={\`${multiline}\`} />`
         }
       ]
     });
@@ -527,35 +527,35 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionAtBeginning}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionAtBeginning}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionAtBeginning}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionAtBeginning}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionAtBeginning}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionAtBeginning}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionAtBeginning}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionInCenter}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionInCenter}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionInCenter}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionInCenter}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionInCenter}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionInCenter}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionInCenter}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionInCenter}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionAtEnd}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionAtEnd}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionAtEnd}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionAtEnd}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionAtEnd}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionAtEnd}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithClassesAroundExpression}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithClassesAroundExpression}\`} />`,
+            jsx: `<img class={\`${singleLineWithClassesAroundExpression}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithClassesAroundExpression}\`} />`,
             options: [{ classesPerLine: 4, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithClassesAroundExpression}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithClassesAroundExpression}\`} />`
+            svelte: `<img class={\`${singleLineWithClassesAroundExpression}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithClassesAroundExpression}\`} />`
           }
         ]
       }
@@ -613,35 +613,35 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
-            jsxOutput: `<div class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
+            jsx: `<img class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
+            jsxOutput: `<img class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
-            svelteOutput: `<div class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`
+            svelte: `<img class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
+            svelteOutput: `<img class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`
           }
         ]
       }
@@ -670,15 +670,15 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            html: `<div class="${singleLine}" />`,
-            htmlOutput: `<div class="${multiline}" />`,
-            jsx: `<div class={\`${singleLine}\`} />`,
-            jsxOutput: `<div class={\`${multiline}\`} />`,
+            html: `<img class="${singleLine}" />`,
+            htmlOutput: `<img class="${multiline}" />`,
+            jsx: `<img class={\`${singleLine}\`} />`,
+            jsxOutput: `<img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<div class="${singleLine}" />`,
-            svelteOutput: `<div class="${multiline}" />`,
-            vue: `<template><div class="${singleLine}" /></template>`,
-            vueOutput: `<template><div class="${multiline}" /></template>`
+            svelte: `<img class="${singleLine}" />`,
+            svelteOutput: `<img class="${multiline}" />`,
+            vue: `<template><img class="${singleLine}" /></template>`,
+            vueOutput: `<template><img class="${multiline}" /></template>`
           }
         ]
       }
@@ -832,15 +832,15 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            html: `<div class="${dirty}" />`,
-            htmlOutput: `<div class="${clean}" />`,
-            jsx: `<div class="${dirty}" />`,
-            jsxOutput: `<div class={\`${clean}\`} />`,
+            html: `<img class="${dirty}" />`,
+            htmlOutput: `<img class="${clean}" />`,
+            jsx: `<img class="${dirty}" />`,
+            jsxOutput: `<img class={\`${clean}\`} />`,
             options: [{ classesPerLine: 3, indent: 2, lineBreakStyle: "windows" }],
-            svelte: `<div class="${dirty}" />`,
-            svelteOutput: `<div class="${clean}" />`,
-            vue: `<template><div class="${dirty}" /></template>`,
-            vueOutput: `<template><div class="${clean}" /></template>`
+            svelte: `<img class="${dirty}" />`,
+            svelteOutput: `<img class="${clean}" />`,
+            vue: `<template><img class="${dirty}" /></template>`,
+            vueOutput: `<template><img class="${clean}" /></template>`
           }
         ]
       }
@@ -860,15 +860,15 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            html: `<div class="${dirty}" />`,
-            htmlOutput: `<div class="${clean}" />`,
-            jsx: `const Test = () => <div class="${dirty}" />;`,
-            jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+            html: `<img class="${dirty}" />`,
+            htmlOutput: `<img class="${clean}" />`,
+            jsx: `const Test = () => <img class="${dirty}" />;`,
+            jsxOutput: `const Test = () => <img class={\`${clean}\`} />;`,
             options: [{ classesPerLine: 3, indent: "tab" }],
-            svelte: `<div class="${dirty}" />`,
-            svelteOutput: `<div class="${clean}" />`,
-            vue: `<template><div class="${dirty}" /></template>`,
-            vueOutput: `<template><div class="${clean}" /></template>`
+            svelte: `<img class="${dirty}" />`,
+            svelteOutput: `<img class="${clean}" />`,
+            vue: `<template><img class="${dirty}" /></template>`,
+            vueOutput: `<template><img class="${clean}" /></template>`
           }
         ]
       }

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -14,28 +14,28 @@ describe(tailwindMultiline.name, () => {
       {
         valid: [
           {
-            html: "<img class=\"\" />",
-            jsx: "<img class=\"\" />",
-            svelte: "<img class=\"\" />",
-            vue: "<template><img class=\"\" /></template>"
+            html: `<img class="" />`,
+            jsx: `<img class="" />`,
+            svelte: `<img class="" />`,
+            vue: `<template><img class="" /></template>`
           },
           {
-            html: "<img class='' />",
-            jsx: "<img class='' />",
-            svelte: "<img class='' />",
-            vue: "<template><img class='' /></template>"
+            html: `<img class='' />`,
+            jsx: `<img class='' />`,
+            svelte: `<img class='' />`,
+            vue: `<template><img class='' /></template>`
           },
           {
-            jsx: "<img class={\"\"} />",
-            svelte: "<img class={\"\"} />"
+            jsx: `<img class={""} />`,
+            svelte: `<img class={""} />`
           },
           {
-            jsx: "<img class={''} />",
-            svelte: "<img class={''} />"
+            jsx: `<img class={''} />`,
+            svelte: `<img class={''} />`
           },
           {
-            jsx: "<img class={``} />",
-            svelte: "<img class={``} />"
+            jsx: `<img class={\`\`} />`,
+            svelte: `<img class={\`\`} />`
           }
         ]
       }
@@ -49,28 +49,28 @@ describe(tailwindMultiline.name, () => {
       {
         valid: [
           {
-            html: "<img class=\"a b c\" />",
-            jsx: "<img class=\"a b c\" />",
-            svelte: "<img class=\"a b c\" />",
-            vue: "<template><img class=\"a b c\" /></template>"
+            html: `<img class="a b c" />`,
+            jsx: `<img class="a b c" />`,
+            svelte: `<img class="a b c" />`,
+            vue: `<template><img class="a b c" /></template>`
           },
           {
-            html: "<img class='a b c' />",
-            jsx: "<img class='a b c' />",
-            svelte: "<img class='a b c' />",
-            vue: "<template><img class='a b c' /></template>"
+            html: `<img class='a b c' />`,
+            jsx: `<img class='a b c' />`,
+            svelte: `<img class='a b c' />`,
+            vue: `<template><img class='a b c' /></template>`
           },
           {
-            jsx: "<img class={\"a b c\"} />",
-            svelte: "<img class={\"a b c\"} />"
+            jsx: `<img class={"a b c"} />`,
+            svelte: `<img class={"a b c"} />`
           },
           {
-            jsx: "<img class={'a b c'} />",
-            svelte: "<img class={'a b c'} />"
+            jsx: `<img class={'a b c'} />`,
+            svelte: `<img class={'a b c'} />`
           },
           {
-            jsx: "<img class={`a b c`} />",
-            svelte: "<img class={`a b c`} />"
+            jsx: `<img class={\`a b c\`} />`,
+            svelte: `<img class={\`a b c\`} />`
           }
         ]
       }
@@ -181,11 +181,11 @@ describe(tailwindMultiline.name, () => {
       {
         valid: [
           {
-            html: "<img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
-            jsx: "<img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
+            html: `<img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
+            jsx: `<img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
             options: [{ printWidth: 0 }],
-            svelte: "<img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
-            vue: "<template><img class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" /></template>"
+            svelte: `<img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
+            vue: `<template><img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" /></template>`
           }
         ]
       }

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -15,26 +15,26 @@ describe(tailwindMultiline.name, () => {
         valid: [
           {
             html: `<img class="" />`,
-            jsx: `<img class="" />`,
+            jsx: `() => <img class="" />`,
             svelte: `<img class="" />`,
             vue: `<template><img class="" /></template>`
           },
           {
             html: `<img class='' />`,
-            jsx: `<img class='' />`,
+            jsx: `() => <img class='' />`,
             svelte: `<img class='' />`,
             vue: `<template><img class='' /></template>`
           },
           {
-            jsx: `<img class={""} />`,
+            jsx: `() => <img class={""} />`,
             svelte: `<img class={""} />`
           },
           {
-            jsx: `<img class={''} />`,
+            jsx: `() => <img class={''} />`,
             svelte: `<img class={''} />`
           },
           {
-            jsx: `<img class={\`\`} />`,
+            jsx: `() => <img class={\`\`} />`,
             svelte: `<img class={\`\`} />`
           }
         ]
@@ -50,26 +50,26 @@ describe(tailwindMultiline.name, () => {
         valid: [
           {
             html: `<img class="a b c" />`,
-            jsx: `<img class="a b c" />`,
+            jsx: `() => <img class="a b c" />`,
             svelte: `<img class="a b c" />`,
             vue: `<template><img class="a b c" /></template>`
           },
           {
             html: `<img class='a b c' />`,
-            jsx: `<img class='a b c' />`,
+            jsx: `() => <img class='a b c' />`,
             svelte: `<img class='a b c' />`,
             vue: `<template><img class='a b c' /></template>`
           },
           {
-            jsx: `<img class={"a b c"} />`,
+            jsx: `() => <img class={"a b c"} />`,
             svelte: `<img class={"a b c"} />`
           },
           {
-            jsx: `<img class={'a b c'} />`,
+            jsx: `() => <img class={'a b c'} />`,
             svelte: `<img class={'a b c'} />`
           },
           {
-            jsx: `<img class={\`a b c\`} />`,
+            jsx: `() => <img class={\`a b c\`} />`,
             svelte: `<img class={\`a b c\`} />`
           }
         ]
@@ -96,8 +96,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<img class="${dirty}" />`,
             htmlOutput: `<img class="${clean}" />`,
-            jsx: `<img class={\`${dirty}\`} />`,
-            jsxOutput: `<img class={\`${clean}\`} />`,
+            jsx: `() => <img class={\`${dirty}\`} />`,
+            jsxOutput: `() => <img class={\`${clean}\`} />`,
             options: [{ printWidth: 60 }],
             svelte: `<img class="${dirty}" />`,
             svelteOutput: `<img class="${clean}" />`,
@@ -131,8 +131,8 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<img class={\`${incorrect}\`} />`,
-            jsxOutput: `<img class={\`${correct}\`} />`,
+            jsx: `() => <img class={\`${incorrect}\`} />`,
+            jsxOutput: `() => <img class={\`${correct}\`} />`,
             options: [{ classesPerLine: 3, group: "newLine", indent: 2 }],
             svelte: `<img class={\`${incorrect}\`} />`,
             svelteOutput: `<img class={\`${correct}\`} />`
@@ -161,8 +161,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<img class="${dirty}" />`,
             htmlOutput: `<img class="${clean}" />`,
-            jsx: `<img class="${dirty}" />`,
-            jsxOutput: `<img class={\`${clean}\`} />`,
+            jsx: `() => <img class="${dirty}" />`,
+            jsxOutput: `() => <img class={\`${clean}\`} />`,
             options: [{ printWidth: 60 }],
             svelte: `<img class="${dirty}" />`,
             svelteOutput: `<img class="${clean}" />`,
@@ -182,7 +182,7 @@ describe(tailwindMultiline.name, () => {
         valid: [
           {
             html: `<img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
-            jsx: `<img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
+            jsx: `() => <img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
             options: [{ printWidth: 0 }],
             svelte: `<img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" />`,
             vue: `<template><img class="this string literal is longer than 80 characters and would be wrapped using the default printWidth" /></template>`
@@ -213,8 +213,8 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<img class={${dirtyDefined}} />`,
-            jsxOutput: `<img class={${cleanDefined}} />`,
+            jsx: `() => <img class={${dirtyDefined}} />`,
+            jsxOutput: `() => <img class={${cleanDefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<img class={${dirtyDefined}} />`,
             svelteOutput: `<img class={${cleanDefined}} />`
@@ -222,7 +222,7 @@ describe(tailwindMultiline.name, () => {
         ],
         valid: [
           {
-            jsx: `<img class={${dirtyUndefined}} />`,
+            jsx: `() => <img class={${dirtyUndefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<img class={${dirtyUndefined}} />`
           }
@@ -237,8 +237,8 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<img class={${dirtyDefined}} />`,
-            jsxOutput: `<img class={${cleanDefined}} />`,
+            jsx: `() => <img class={${dirtyDefined}} />`,
+            jsxOutput: `() => <img class={${cleanDefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<img class={${dirtyDefined}} />`,
             svelteOutput: `<img class={${cleanDefined}} />`
@@ -246,7 +246,7 @@ describe(tailwindMultiline.name, () => {
         ],
         valid: [
           {
-            jsx: `<img class={${dirtyUndefined}} />`,
+            jsx: `() => <img class={${dirtyUndefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<img class={${dirtyUndefined}} />`
           }
@@ -364,28 +364,28 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 1,
-            jsx: `<img class="${singleLine}" />`,
-            jsxOutput: `<img class={\`${multiline}\`} />`,
+            jsx: `() => <img class="${singleLine}" />`,
+            jsxOutput: `() => <img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }]
           },
           {
             errors: 1,
-            jsx: `<img class='${singleLine}' />`,
-            jsxOutput: `<img class={\`${multiline}\`} />`,
+            jsx: `() => <img class='${singleLine}' />`,
+            jsxOutput: `() => <img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }]
           },
           {
             errors: 1,
-            jsx: `<img class={"${singleLine}"} />`,
-            jsxOutput: `<img class={\`${multiline}\`} />`,
+            jsx: `() => <img class={"${singleLine}"} />`,
+            jsxOutput: `() => <img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={"${singleLine}"} />`,
             svelteOutput: `<img class={\`${multiline}\`} />`
           },
           {
             errors: 1,
-            jsx: `<img class={'${singleLine}'} />`,
-            jsxOutput: `<img class={\`${multiline}\`} />`,
+            jsx: `() => <img class={'${singleLine}'} />`,
+            jsxOutput: `() => <img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={'${singleLine}'} />`,
             svelteOutput: `<img class={\`${multiline}\`} />`
@@ -393,7 +393,7 @@ describe(tailwindMultiline.name, () => {
         ],
         valid: [
           {
-            jsx: `<img class={\`${multiline}\`} />`,
+            jsx: `() => <img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${multiline}\`} />`
           },
@@ -429,8 +429,8 @@ describe(tailwindMultiline.name, () => {
           errors: 1,
           html: `<img class="${singleLine}" />`,
           htmlOutput: `<img class="${multiline}" />`,
-          jsx: `<img class="${singleLine}" />`,
-          jsxOutput: `<img class={\`${multiline}\`} />`,
+          jsx: `() => <img class="${singleLine}" />`,
+          jsxOutput: `() => <img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<img class="${singleLine}" />`,
           svelteOutput: `<img class="${multiline}" />`,
@@ -441,8 +441,8 @@ describe(tailwindMultiline.name, () => {
           errors: 1,
           html: `<img class='${singleLine}' />`,
           htmlOutput: `<img class='${multiline}' />`,
-          jsx: `<img class='${singleLine}' />`,
-          jsxOutput: `<img class={\`${multiline}\`} />`,
+          jsx: `() => <img class='${singleLine}' />`,
+          jsxOutput: `() => <img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<img class='${singleLine}' />`,
           svelteOutput: `<img class='${multiline}' />`,
@@ -451,24 +451,24 @@ describe(tailwindMultiline.name, () => {
         },
         {
           errors: 1,
-          jsx: `<img class={\`${singleLine}\`} />`,
-          jsxOutput: `<img class={\`${multiline}\`} />`,
+          jsx: `() => <img class={\`${singleLine}\`} />`,
+          jsxOutput: `() => <img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<img class={\`${singleLine}\`} />`,
           svelteOutput: `<img class={\`${multiline}\`} />`
         },
         {
           errors: 1,
-          jsx: `<img class={"${singleLine}"} />`,
-          jsxOutput: `<img class={\`${multiline}\`} />`,
+          jsx: `() => <img class={"${singleLine}"} />`,
+          jsxOutput: `() => <img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<img class={"${singleLine}"} />`,
           svelteOutput: `<img class={\`${multiline}\`} />`
         },
         {
           errors: 1,
-          jsx: `<img class={'${singleLine}'} />`,
-          jsxOutput: `<img class={\`${multiline}\`} />`,
+          jsx: `() => <img class={'${singleLine}'} />`,
+          jsxOutput: `() => <img class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<img class={'${singleLine}'} />`,
           svelteOutput: `<img class={\`${multiline}\`} />`
@@ -527,32 +527,32 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionAtBeginning}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionAtBeginning}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionAtBeginning}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionAtBeginning}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionAtBeginning}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionInCenter}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionInCenter}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionInCenter}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionInCenter}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionInCenter}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionInCenter}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionAtEnd}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionAtEnd}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionAtEnd}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionAtEnd}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithClassesAroundExpression}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithClassesAroundExpression}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithClassesAroundExpression}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithClassesAroundExpression}\`} />`,
             options: [{ classesPerLine: 4, indent: 2 }],
             svelte: `<img class={\`${singleLineWithClassesAroundExpression}\`} />`,
             svelteOutput: `<img class={\`${multilineWithClassesAroundExpression}\`} />`
@@ -613,32 +613,32 @@ describe(tailwindMultiline.name, () => {
         invalid: [
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
-            jsxOutput: `<img class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
+            jsx: `() => <img class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
             svelteOutput: `<img class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`
@@ -672,8 +672,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<img class="${singleLine}" />`,
             htmlOutput: `<img class="${multiline}" />`,
-            jsx: `<img class={\`${singleLine}\`} />`,
-            jsxOutput: `<img class={\`${multiline}\`} />`,
+            jsx: `() => <img class={\`${singleLine}\`} />`,
+            jsxOutput: `() => <img class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<img class="${singleLine}" />`,
             svelteOutput: `<img class="${multiline}" />`,
@@ -834,8 +834,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<img class="${dirty}" />`,
             htmlOutput: `<img class="${clean}" />`,
-            jsx: `<img class="${dirty}" />`,
-            jsxOutput: `<img class={\`${clean}\`} />`,
+            jsx: `() => <img class="${dirty}" />`,
+            jsxOutput: `() => <img class={\`${clean}\`} />`,
             options: [{ classesPerLine: 3, indent: 2, lineBreakStyle: "windows" }],
             svelte: `<img class="${dirty}" />`,
             svelteOutput: `<img class="${clean}" />`,
@@ -862,8 +862,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<img class="${dirty}" />`,
             htmlOutput: `<img class="${clean}" />`,
-            jsx: `const Test = () => <img class="${dirty}" />;`,
-            jsxOutput: `const Test = () => <img class={\`${clean}\`} />;`,
+            jsx: `() => <img class="${dirty}" />;`,
+            jsxOutput: `() => <img class={\`${clean}\`} />;`,
             options: [{ classesPerLine: 3, indent: "tab" }],
             svelte: `<img class="${dirty}" />`,
             svelteOutput: `<img class="${clean}" />`,

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -1,6 +1,6 @@
 import { createTrimTag } from "tests/utils";
 import { lint, TEST_SYNTAXES } from "tests/utils.js";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 
 import { tailwindMultiline } from "readable-tailwind:rules:tailwind-multiline.js";
 
@@ -8,73 +8,73 @@ import { tailwindMultiline } from "readable-tailwind:rules:tailwind-multiline.js
 describe(tailwindMultiline.name, () => {
 
   it("should not wrap empty strings", () => {
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         valid: [
           {
             html: "<div class=\"\" />",
-            jsx: "const Test = () => <div class=\"\" />;",
+            jsx: "<div class=\"\" />",
             svelte: "<div class=\"\" />",
             vue: "<template><div class=\"\" /></template>"
           },
           {
             html: "<div class='' />",
-            jsx: "const Test = () => <div class='' />;",
+            jsx: "<div class='' />",
             svelte: "<div class='' />",
             vue: "<template><div class='' /></template>"
           },
           {
-            jsx: "const Test = () => <div class={\"\"} />;",
+            jsx: "<div class={\"\"} />",
             svelte: "<div class={\"\"} />"
           },
           {
-            jsx: "const Test = () => <div class={''} />;",
+            jsx: "<div class={''} />",
             svelte: "<div class={''} />"
           },
           {
-            jsx: "const Test = () => <div class={``} />;",
+            jsx: "<div class={``} />",
             svelte: "<div class={``} />"
           }
         ]
       }
-    )).toBeUndefined();
+    );
   });
 
   it("should not wrap short lines", () => {
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         valid: [
           {
             html: "<div class=\"a b c\" />",
-            jsx: "const Test = () => <div class=\"a b c\" />;",
+            jsx: "<div class=\"a b c\" />",
             svelte: "<div class=\"a b c\" />",
             vue: "<template><div class=\"a b c\" /></template>"
           },
           {
             html: "<div class='a b c' />",
-            jsx: "const Test = () => <div class='a b c' />;",
+            jsx: "<div class='a b c' />",
             svelte: "<div class='a b c' />",
             vue: "<template><div class='a b c' /></template>"
           },
           {
-            jsx: "const Test = () => <div class={\"a b c\"} />;",
+            jsx: "<div class={\"a b c\"} />",
             svelte: "<div class={\"a b c\"} />"
           },
           {
-            jsx: "const Test = () => <div class={'a b c'} />;",
+            jsx: "<div class={'a b c'} />",
             svelte: "<div class={'a b c'} />"
           },
           {
-            jsx: "const Test = () => <div class={`a b c`} />;",
+            jsx: "<div class={`a b c`} />",
             svelte: "<div class={`a b c`} />"
           }
         ]
       }
-    )).toBeUndefined();
+    );
   });
 
   it("should collapse unnecessarily wrapped short lines", () => {
@@ -87,7 +87,7 @@ describe(tailwindMultiline.name, () => {
 
     const clean = "a b";
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -96,8 +96,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<div class="${dirty}" />`,
             htmlOutput: `<div class="${clean}" />`,
-            jsx: `const Test = () => <div class={\`${dirty}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+            jsx: `<div class={\`${dirty}\`} />`,
+            jsxOutput: `<div class={\`${clean}\`} />`,
             options: [{ printWidth: 60 }],
             svelte: `<div class="${dirty}" />`,
             svelteOutput: `<div class="${clean}" />`,
@@ -106,7 +106,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
   });
 
   it("should wrap and not collapse short lines containing expressions", () => {
@@ -114,30 +114,32 @@ describe(tailwindMultiline.name, () => {
     const trim = createTrimTag(4);
 
     const expression = "${true ? ' true ' : ' false '}";
-    const invalid = trim`
+
+    const incorrect = trim`
       a ${expression}
     `;
-    const valid = trim`
+
+    const correct = trim`
       a
       ${expression}
     `;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 1,
-            jsx: `const Test = () => <div class={\`${invalid}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${valid}\`} />;`,
+            jsx: `<div class={\`${incorrect}\`} />`,
+            jsxOutput: `<div class={\`${correct}\`} />`,
             options: [{ classesPerLine: 3, group: "newLine", indent: 2 }],
-            svelte: `<div class={\`${invalid}\`} />`,
-            svelteOutput: `<div class={\`${valid}\`} />`
+            svelte: `<div class={\`${incorrect}\`} />`,
+            svelteOutput: `<div class={\`${correct}\`} />`
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -150,7 +152,7 @@ describe(tailwindMultiline.name, () => {
       this string literal is exactly 54 characters in length
     `;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -159,8 +161,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<div class="${dirty}" />`,
             htmlOutput: `<div class="${clean}" />`,
-            jsx: `const Test = () => <div class="${dirty}" />;`,
-            jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+            jsx: `<div class="${dirty}" />`,
+            jsxOutput: `<div class={\`${clean}\`} />`,
             options: [{ printWidth: 60 }],
             svelte: `<div class="${dirty}" />`,
             svelteOutput: `<div class="${clean}" />`,
@@ -169,25 +171,25 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
   });
 
   it("should disable the `printWidth` limit when set to `0`", () => {
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         valid: [
           {
             html: "<div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
-            jsx: "const Test = () => <div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />;",
+            jsx: "<div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
             options: [{ printWidth: 0 }],
             svelte: "<div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" />",
             vue: "<template><div class=\"this string literal is longer than 80 characters and would be wrapped using the default printWidth\" /></template>"
           }
         ]
       }
-    )).toBeUndefined();
+    );
   });
 
   it("should change the quotes in defined call signatures to template literals", () => {
@@ -204,15 +206,15 @@ describe(tailwindMultiline.name, () => {
 
     const dirtyUndefined = "notDefined('a b c d e f g h')";
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 1,
-            jsx: `const Test = () => <div class={${dirtyDefined}} />;`,
-            jsxOutput: `const Test = () => <div class={${cleanDefined}} />;`,
+            jsx: `<div class={${dirtyDefined}} />`,
+            jsxOutput: `<div class={${cleanDefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<div class={${dirtyDefined}} />`,
             svelteOutput: `<div class={${cleanDefined}} />`
@@ -220,23 +222,23 @@ describe(tailwindMultiline.name, () => {
         ],
         valid: [
           {
-            jsx: `const Test = () => <div class={${dirtyUndefined}} />;`,
+            jsx: `<div class={${dirtyUndefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<div class={${dirtyUndefined}} />`
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 1,
-            jsx: `const Test = () => <div class={${dirtyDefined}} />;`,
-            jsxOutput: `const Test = () => <div class={${cleanDefined}} />;`,
+            jsx: `<div class={${dirtyDefined}} />`,
+            jsxOutput: `<div class={${cleanDefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<div class={${dirtyDefined}} />`,
             svelteOutput: `<div class={${cleanDefined}} />`
@@ -244,13 +246,14 @@ describe(tailwindMultiline.name, () => {
         ],
         valid: [
           {
-            jsx: `const Test = () => <div class={${dirtyUndefined}} />;`,
+            jsx: `<div class={${dirtyUndefined}} />`,
             options: [{ callees: ["defined"], classesPerLine: 3, indent: 2 }],
             svelte: `<div class={${dirtyUndefined}} />`
           }
         ]
       }
-    )).toBeUndefined();
+    );
+
   });
 
   it("should wrap string literals in call signature arguments matched by a regex", () => {
@@ -309,7 +312,7 @@ describe(tailwindMultiline.name, () => {
       }
     );`;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -339,7 +342,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -354,35 +357,35 @@ describe(tailwindMultiline.name, () => {
       g h
     `;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 1,
-            jsx: `const Test = () => <div class="${singleLine}" />;`,
-            jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+            jsx: `<div class="${singleLine}" />`,
+            jsxOutput: `<div class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }]
           },
           {
             errors: 1,
-            jsx: `const Test = () => <div class='${singleLine}' />;`,
-            jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+            jsx: `<div class='${singleLine}' />`,
+            jsxOutput: `<div class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }]
           },
           {
             errors: 1,
-            jsx: `const Test = () => <div class={"${singleLine}"} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+            jsx: `<div class={"${singleLine}"} />`,
+            jsxOutput: `<div class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={"${singleLine}"} />`,
             svelteOutput: `<div class={\`${multiline}\`} />`
           },
           {
             errors: 1,
-            jsx: `const Test = () => <div class={'${singleLine}'} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+            jsx: `<div class={'${singleLine}'} />`,
+            jsxOutput: `<div class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={'${singleLine}'} />`,
             svelteOutput: `<div class={\`${multiline}\`} />`
@@ -390,7 +393,7 @@ describe(tailwindMultiline.name, () => {
         ],
         valid: [
           {
-            jsx: `const Test = () => <div class={\`${multiline}\`} />;`,
+            jsx: `<div class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${multiline}\`} />`
           },
@@ -406,7 +409,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
   });
 
   it("should wrap long lines on to multiple lines", () => {
@@ -420,14 +423,14 @@ describe(tailwindMultiline.name, () => {
       g h
     `;
 
-    expect(void lint(tailwindMultiline, TEST_SYNTAXES, {
+    lint(tailwindMultiline, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
           html: `<div class="${singleLine}" />`,
           htmlOutput: `<div class="${multiline}" />`,
-          jsx: `const Test = () => <div class="${singleLine}" />;`,
-          jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+          jsx: `<div class="${singleLine}" />`,
+          jsxOutput: `<div class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<div class="${singleLine}" />`,
           svelteOutput: `<div class="${multiline}" />`,
@@ -438,8 +441,8 @@ describe(tailwindMultiline.name, () => {
           errors: 1,
           html: `<div class='${singleLine}' />`,
           htmlOutput: `<div class='${multiline}' />`,
-          jsx: `const Test = () => <div class='${singleLine}' />;`,
-          jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+          jsx: `<div class='${singleLine}' />`,
+          jsxOutput: `<div class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<div class='${singleLine}' />`,
           svelteOutput: `<div class='${multiline}' />`,
@@ -448,30 +451,30 @@ describe(tailwindMultiline.name, () => {
         },
         {
           errors: 1,
-          jsx: `const Test = () => <div class={\`${singleLine}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+          jsx: `<div class={\`${singleLine}\`} />`,
+          jsxOutput: `<div class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<div class={\`${singleLine}\`} />`,
           svelteOutput: `<div class={\`${multiline}\`} />`
         },
         {
           errors: 1,
-          jsx: `const Test = () => <div class={"${singleLine}"} />;`,
-          jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+          jsx: `<div class={"${singleLine}"} />`,
+          jsxOutput: `<div class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<div class={"${singleLine}"} />`,
           svelteOutput: `<div class={\`${multiline}\`} />`
         },
         {
           errors: 1,
-          jsx: `const Test = () => <div class={'${singleLine}'} />;`,
-          jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+          jsx: `<div class={'${singleLine}'} />`,
+          jsxOutput: `<div class={\`${multiline}\`} />`,
           options: [{ classesPerLine: 3, indent: 2 }],
           svelte: `<div class={'${singleLine}'} />`,
           svelteOutput: `<div class={\`${multiline}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
   });
 
   it("should wrap expressions correctly", () => {
@@ -517,46 +520,46 @@ describe(tailwindMultiline.name, () => {
       g h
     `;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionAtBeginning}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionAtBeginning}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionAtBeginning}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionAtBeginning}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionAtBeginning}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionInCenter}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionInCenter}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionInCenter}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionInCenter}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionInCenter}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionInCenter}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionAtEnd}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionAtEnd}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionAtEnd}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionAtEnd}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithClassesAroundExpression}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithClassesAroundExpression}\`} />;`,
+            jsx: `<div class={\`${singleLineWithClassesAroundExpression}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithClassesAroundExpression}\`} />`,
             options: [{ classesPerLine: 4, indent: 2 }],
             svelte: `<div class={\`${singleLineWithClassesAroundExpression}\`} />`,
             svelteOutput: `<div class={\`${multilineWithClassesAroundExpression}\`} />`
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -603,46 +606,46 @@ describe(tailwindMultiline.name, () => {
       h${expression}
     `;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionAtBeginningWithStickyClassAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtBeginning}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionInCenterWithStickyClassAtEnd}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionInCenterWithStickyClassAtEnd}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />;`,
+            jsx: `<div class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
+            jsxOutput: `<div class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class={\`${singleLineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`,
             svelteOutput: `<div class={\`${multilineWithExpressionAtEndWithStickyClassAtBeginning}\`} />`
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -660,7 +663,7 @@ describe(tailwindMultiline.name, () => {
       g-3:a g-3:b
     `;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -669,8 +672,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<div class="${singleLine}" />`,
             htmlOutput: `<div class="${multiline}" />`,
-            jsx: `const Test = () => <div class={\`${singleLine}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${multiline}\`} />;`,
+            jsx: `<div class={\`${singleLine}\`} />`,
+            jsxOutput: `<div class={\`${multiline}\`} />`,
             options: [{ classesPerLine: 3, indent: 2 }],
             svelte: `<div class="${singleLine}" />`,
             svelteOutput: `<div class="${multiline}" />`,
@@ -679,7 +682,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -695,7 +698,7 @@ describe(tailwindMultiline.name, () => {
       g h
     \`;`;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -719,7 +722,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -761,7 +764,7 @@ describe(tailwindMultiline.name, () => {
       }
     };`;
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -813,7 +816,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -822,7 +825,7 @@ describe(tailwindMultiline.name, () => {
     const dirty = " a b c d e f g h ";
     const clean = "\r\n  a b c\r\n  d e f\r\n  g h\r\n";
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -831,8 +834,8 @@ describe(tailwindMultiline.name, () => {
             errors: 1,
             html: `<div class="${dirty}" />`,
             htmlOutput: `<div class="${clean}" />`,
-            jsx: `const Test = () => <div class="${dirty}" />;`,
-            jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+            jsx: `<div class="${dirty}" />`,
+            jsxOutput: `<div class={\`${clean}\`} />`,
             options: [{ classesPerLine: 3, indent: 2, lineBreakStyle: "windows" }],
             svelte: `<div class="${dirty}" />`,
             svelteOutput: `<div class="${clean}" />`,
@@ -841,7 +844,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -850,7 +853,7 @@ describe(tailwindMultiline.name, () => {
     const dirty = " a b c d e f g h ";
     const clean = "\n\ta b c\n\td e f\n\tg h\n";
 
-    expect(void lint(
+    lint(
       tailwindMultiline,
       TEST_SYNTAXES,
       {
@@ -869,8 +872,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
-
+    )
   });
-
+  
 });

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -872,7 +872,7 @@ describe(tailwindMultiline.name, () => {
           }
         ]
       }
-    )
+    );
   });
-  
+
 });

--- a/src/rules/tailwind-no-unnecessary-whitespace.test.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.test.ts
@@ -13,8 +13,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<img class="  b  a  " />`,
           htmlOutput: `<img class="b a" />`,
-          jsx: `<img class="  b  a  " />`,
-          jsxOutput: `<img class="b a" />`,
+          jsx: `() => <img class="  b  a  " />`,
+          jsxOutput: `() => <img class="b a" />`,
           svelte: `<img class="  b  a  " />`,
           svelteOutput: `<img class="b a" />`,
           vue: `<template><img class="  b  a  " /></template>`,
@@ -36,8 +36,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<img class="${dirtyEmptyMultilineString}" />`,
           htmlOutput: `<img class="${cleanEmptyMultilineString}" />`,
-          jsx: `<img class="${dirtyEmptyMultilineString}" />`,
-          jsxOutput: `<img class="${cleanEmptyMultilineString}" />`,
+          jsx: `() => <img class="${dirtyEmptyMultilineString}" />`,
+          jsxOutput: `() => <img class="${cleanEmptyMultilineString}" />`,
           svelte: `<img class="${dirtyEmptyMultilineString}" />`,
           svelteOutput: `<img class="${cleanEmptyMultilineString}" />`,
           vue: `<template><img class="${dirtyEmptyMultilineString}" /></template>`,
@@ -54,8 +54,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<img class="  b  a  " />`,
           htmlOutput: `<img class="b a" />`,
-          jsx: `<img class="  b  a  " />`,
-          jsxOutput: `<img class="b a" />`,
+          jsx: `() => <img class="  b  a  " />`,
+          jsxOutput: `() => <img class="b a" />`,
           svelte: `<img class="  b  a  " />`,
           svelteOutput: `<img class="b a" />`,
           vue: `<template><img class="  b  a  " /></template>`,
@@ -65,8 +65,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<img class='  b  a  ' />`,
           htmlOutput: `<img class='b a' />`,
-          jsx: `<img class='  b  a  ' />`,
-          jsxOutput: `<img class='b a' />`,
+          jsx: `() => <img class='  b  a  ' />`,
+          jsxOutput: `() => <img class='b a' />`,
           svelte: `<img class='  b  a  ' />`,
           svelteOutput: `<img class='b a' />`,
           vue: `<template><img class='  b  a  ' /></template>`,
@@ -74,22 +74,22 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
         },
         {
           errors: 1,
-          jsx: `<img class={\`  b  a  \`} />`,
-          jsxOutput: `<img class={\`b a\`} />`,
+          jsx: `() => <img class={\`  b  a  \`} />`,
+          jsxOutput: `() => <img class={\`b a\`} />`,
           svelte: `<img class={\`  b  a  \`} />`,
           svelteOutput: `<img class={\`b a\`} />`
         },
         {
           errors: 1,
-          jsx: `<img class={"  b  a  "} />`,
-          jsxOutput: `<img class={"b a"} />`,
+          jsx: `() => <img class={"  b  a  "} />`,
+          jsxOutput: `() => <img class={"b a"} />`,
           svelte: `<img class={"  b  a  "} />`,
           svelteOutput: `<img class={"b a"} />`
         },
         {
           errors: 1,
-          jsx: `<img class={'  b  a  '} />`,
-          jsxOutput: `<img class={'b a'} />`,
+          jsx: `() => <img class={'  b  a  '} />`,
+          jsxOutput: `() => <img class={'b a'} />`,
           svelte: `<img class={'  b  a  '} />`,
           svelteOutput: `<img class={'b a'} />`
         }
@@ -102,8 +102,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<img class={\`  b  a  \${"  c  "}  d  \`} />`,
-          jsxOutput: `<img class={\`b a \${"  c  "} d\`} />`,
+          jsx: `() => <img class={\`  b  a  \${"  c  "}  d  \`} />`,
+          jsxOutput: `() => <img class={\`b a \${"  c  "} d\`} />`,
           svelte: `<img class={\`  b  a  \${"  c  "}  d  \`} />`,
           svelteOutput: `<img class={\`b a \${"  c  "} d\`} />`
         }
@@ -133,8 +133,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<img class="${dirty}" />`,
           htmlOutput: `<img class="${clean}" />`,
-          jsx: `<img class={\`${dirty}\`} />`,
-          jsxOutput: `<img class={\`${clean}\`} />`,
+          jsx: `() => <img class={\`${dirty}\`} />`,
+          jsxOutput: `() => <img class={\`${clean}\`} />`,
           svelte: `<img class={\`${dirty}\`} />`,
           svelteOutput: `<img class={\`${clean}\`} />`,
           vue: `<template><img class="${dirty}" /></template>`,
@@ -184,22 +184,22 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          jsx: `<img class={\`${dirtyExpressionAtStart}\`} />`,
-          jsxOutput: `<img class={\`${cleanExpressionAtStart}\`} />`,
+          jsx: `() => <img class={\`${dirtyExpressionAtStart}\`} />`,
+          jsxOutput: `() => <img class={\`${cleanExpressionAtStart}\`} />`,
           svelte: `<img class={\`${dirtyExpressionAtStart}\`} />`,
           svelteOutput: `<img class={\`${cleanExpressionAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `<img class={\`${dirtyExpressionBetween}\`} />`,
-          jsxOutput: `<img class={\`${cleanExpressionBetween}\`} />`,
+          jsx: `() => <img class={\`${dirtyExpressionBetween}\`} />`,
+          jsxOutput: `() => <img class={\`${cleanExpressionBetween}\`} />`,
           svelte: `<img class={\`${dirtyExpressionBetween}\`} />`,
           svelteOutput: `<img class={\`${cleanExpressionBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `<img class={\`${dirtyExpressionAtEnd}\`} />`,
-          jsxOutput: `<img class={\`${cleanExpressionAtEnd}\`} />`,
+          jsx: `() => <img class={\`${dirtyExpressionAtEnd}\`} />`,
+          jsxOutput: `() => <img class={\`${cleanExpressionAtEnd}\`} />`,
           svelte: `<img class={\`${dirtyExpressionAtEnd}\`} />`,
           svelteOutput: `<img class={\`${cleanExpressionAtEnd}\`} />`
         }
@@ -225,22 +225,22 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<img class={\`${invalidAtStart}\`} />`,
-          jsxOutput: `<img class={\`${validAtStart}\`} />`,
+          jsx: `() => <img class={\`${invalidAtStart}\`} />`,
+          jsxOutput: `() => <img class={\`${validAtStart}\`} />`,
           svelte: `<img class={\`${invalidAtStart}\`} />`,
           svelteOutput: `<img class={\`${validAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `<img class={\`${invalidBetween}\`} />`,
-          jsxOutput: `<img class={\`${validBetween}\`} />`,
+          jsx: `() => <img class={\`${invalidBetween}\`} />`,
+          jsxOutput: `() => <img class={\`${validBetween}\`} />`,
           svelte: `<img class={\`${invalidBetween}\`} />`,
           svelteOutput: `<img class={\`${validBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `<img class={\`${invalidAtEnd}\`} />`,
-          jsxOutput: `<img class={\`${validAtEnd}\`} />`,
+          jsx: `() => <img class={\`${invalidAtEnd}\`} />`,
+          jsxOutput: `() => <img class={\`${validAtEnd}\`} />`,
           svelte: `<img class={\`${invalidAtEnd}\`} />`,
           svelteOutput: `<img class={\`${validAtEnd}\`} />`
         }
@@ -266,22 +266,22 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<img class={\`${invalidAtStart}\`} />`,
-          jsxOutput: `<img class={\`${validAtStart}\`} />`,
+          jsx: `() => <img class={\`${invalidAtStart}\`} />`,
+          jsxOutput: `() => <img class={\`${validAtStart}\`} />`,
           svelte: `<img class={\`${invalidAtStart}\`} />`,
           svelteOutput: `<img class={\`${validAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `<img class={\`${invalidBetween}\`} />`,
-          jsxOutput: `<img class={\`${validBetween}\`} />`,
+          jsx: `() => <img class={\`${invalidBetween}\`} />`,
+          jsxOutput: `() => <img class={\`${validBetween}\`} />`,
           svelte: `<img class={\`${invalidBetween}\`} />`,
           svelteOutput: `<img class={\`${validBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `<img class={\`${invalidAtEnd}\`} />`,
-          jsxOutput: `<img class={\`${validAtEnd}\`} />`,
+          jsx: `() => <img class={\`${invalidAtEnd}\`} />`,
+          jsxOutput: `() => <img class={\`${validAtEnd}\`} />`,
           svelte: `<img class={\`${invalidAtEnd}\`} />`,
           svelteOutput: `<img class={\`${validAtEnd}\`} />`
         }
@@ -313,15 +313,15 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `<img class={\`${validSeparateLineAtStart}\`} />`,
+          jsx: `() => <img class={\`${validSeparateLineAtStart}\`} />`,
           svelte: `<img class={\`${validSeparateLineAtStart}\`} />`
         },
         {
-          jsx: `<img class={\`${validSeparateLineBetween}\`} />`,
+          jsx: `() => <img class={\`${validSeparateLineBetween}\`} />`,
           svelte: `<img class={\`${validSeparateLineBetween}\`} />`
         },
         {
-          jsx: `<img class={\`${validSeparateLineAtEnd}\`} />`,
+          jsx: `() => <img class={\`${validSeparateLineAtEnd}\`} />`,
           svelte: `<img class={\`${validSeparateLineAtEnd}\`} />`
         }
       ]
@@ -335,8 +335,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 3,
-          jsx: `<img class={\`  \${" b "}  a  d  \${"  c  "}  \`} />`,
-          jsxOutput: `<img class={\`\${" b "} a d \${"  c  "}\`} />`,
+          jsx: `() => <img class={\`  \${" b "}  a  d  \${"  c  "}  \`} />`,
+          jsxOutput: `() => <img class={\`\${" b "} a d \${"  c  "}\`} />`,
           svelte: `<img class={\`  \${" b "}  a  d  \${"  c  "}  \`} />`,
           svelteOutput: `<img class={\`\${" b "} a d \${"  c  "}\`} />`
         }
@@ -379,8 +379,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
         },
         {
           errors: 1,
-          jsx: `<img class={\`${uncleanedMultilineString}\`} />`,
-          jsxOutput: `<img class={\`${cleanedMultilineString}\`} />`,
+          jsx: `() => <img class={\`${uncleanedMultilineString}\`} />`,
+          jsxOutput: `() => <img class={\`${cleanedMultilineString}\`} />`,
           svelte: `<img class={\`${uncleanedMultilineString}\`} />`,
           svelteOutput: `<img class={\`${cleanedMultilineString}\`} />`
         },
@@ -388,8 +388,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<img class='${uncleanedMultilineString}' />`,
           htmlOutput: `<img class='${cleanedSinglelineString}' />`,
-          jsx: `<img class={\`${uncleanedMultilineString}\`} />`,
-          jsxOutput: `<img class={\`${cleanedSinglelineString}\`} />`,
+          jsx: `() => <img class={\`${uncleanedMultilineString}\`} />`,
+          jsxOutput: `() => <img class={\`${cleanedSinglelineString}\`} />`,
           options: [{ allowMultiline: false }],
           svelte: `<img class={\`${uncleanedMultilineString}\`} />`,
           svelteOutput: `<img class={\`${cleanedSinglelineString}\`} />`,
@@ -400,13 +400,13 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       valid: [
         {
           html: `<img class="${cleanedMultilineString}" />`,
-          jsx: `<img class={\`${cleanedMultilineString}\`} />`,
+          jsx: `() => <img class={\`${cleanedMultilineString}\`} />`,
           svelte: `<img class="${cleanedMultilineString}" />`,
           vue: `<template><img class="${cleanedMultilineString}" /></template>`
         },
         {
           html: `<img class="${cleanedSinglelineString}" />`,
-          jsx: `<img class="${cleanedSinglelineString}" />`,
+          jsx: `() => <img class="${cleanedSinglelineString}" />`,
           svelte: `<img class="${cleanedSinglelineString}" />`,
           vue: `<template><img class="${cleanedSinglelineString}" /></template>`
         }
@@ -437,15 +437,15 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `<img class={\`${validAtStart}\`} />`,
+          jsx: `() => <img class={\`${validAtStart}\`} />`,
           svelte: `<img class={\`${validAtStart}\`} />`
         },
         {
-          jsx: `<img class={\`${validAround}\`} />`,
+          jsx: `() => <img class={\`${validAround}\`} />`,
           svelte: `<img class={\`${validAround}\`} />`
         },
         {
-          jsx: `<img class={\`${validAtEnd}\`} />`,
+          jsx: `() => <img class={\`${validAtEnd}\`} />`,
           svelte: `<img class={\`${validAtEnd}\`} />`
         }
       ]
@@ -611,8 +611,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          jsx: `<img class={\`${dirtyDefinedMultiline}\`} />`,
-          jsxOutput: `<img class={\`${cleanDefinedMultiline}\`} />`,
+          jsx: `() => <img class={\`${dirtyDefinedMultiline}\`} />`,
+          jsxOutput: `() => <img class={\`${cleanDefinedMultiline}\`} />`,
           options: [{ callees: ["defined"] }],
           svelte: `<img class={\`${dirtyDefinedMultiline}\`} />`,
           svelteOutput: `<img class={\`${cleanDefinedMultiline}\`} />`
@@ -620,7 +620,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       ],
       valid: [
         {
-          jsx: `<img class={\`${dirtyUndefinedMultiline}\`} />`,
+          jsx: `() => <img class={\`${dirtyUndefinedMultiline}\`} />`,
           svelte: `<img class={\`${dirtyUndefinedMultiline}\`} />`
         }
       ]

--- a/src/rules/tailwind-no-unnecessary-whitespace.test.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.test.ts
@@ -11,14 +11,14 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          html: `<div class="  b  a  " />`,
-          htmlOutput: `<div class="b a" />`,
-          jsx: `<div class="  b  a  " />`,
-          jsxOutput: `<div class="b a" />`,
-          svelte: `<div class="  b  a  " />`,
-          svelteOutput: `<div class="b a" />`,
-          vue: `<template><div class="  b  a  " /></template>`,
-          vueOutput: `<template><div class="b a" /></template>`
+          html: `<img class="  b  a  " />`,
+          htmlOutput: `<img class="b a" />`,
+          jsx: `<img class="  b  a  " />`,
+          jsxOutput: `<img class="b a" />`,
+          svelte: `<img class="  b  a  " />`,
+          svelteOutput: `<img class="b a" />`,
+          vue: `<template><img class="  b  a  " /></template>`,
+          vueOutput: `<template><img class="b a" /></template>`
         }
       ]
     });
@@ -34,14 +34,14 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          html: `<div class="${dirtyEmptyMultilineString}" />`,
-          htmlOutput: `<div class="${cleanEmptyMultilineString}" />`,
-          jsx: `<div class="${dirtyEmptyMultilineString}" />`,
-          jsxOutput: `<div class="${cleanEmptyMultilineString}" />`,
-          svelte: `<div class="${dirtyEmptyMultilineString}" />`,
-          svelteOutput: `<div class="${cleanEmptyMultilineString}" />`,
-          vue: `<template><div class="${dirtyEmptyMultilineString}" /></template>`,
-          vueOutput: `<template><div class="${cleanEmptyMultilineString}" /></template>`
+          html: `<img class="${dirtyEmptyMultilineString}" />`,
+          htmlOutput: `<img class="${cleanEmptyMultilineString}" />`,
+          jsx: `<img class="${dirtyEmptyMultilineString}" />`,
+          jsxOutput: `<img class="${cleanEmptyMultilineString}" />`,
+          svelte: `<img class="${dirtyEmptyMultilineString}" />`,
+          svelteOutput: `<img class="${cleanEmptyMultilineString}" />`,
+          vue: `<template><img class="${dirtyEmptyMultilineString}" /></template>`,
+          vueOutput: `<template><img class="${cleanEmptyMultilineString}" /></template>`
         }
       ]
     });
@@ -52,46 +52,46 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          html: `<div class="  b  a  " />`,
-          htmlOutput: `<div class="b a" />`,
-          jsx: `<div class="  b  a  " />`,
-          jsxOutput: `<div class="b a" />`,
-          svelte: `<div class="  b  a  " />`,
-          svelteOutput: `<div class="b a" />`,
-          vue: `<template><div class="  b  a  " /></template>`,
-          vueOutput: `<template><div class="b a" /></template>`
+          html: `<img class="  b  a  " />`,
+          htmlOutput: `<img class="b a" />`,
+          jsx: `<img class="  b  a  " />`,
+          jsxOutput: `<img class="b a" />`,
+          svelte: `<img class="  b  a  " />`,
+          svelteOutput: `<img class="b a" />`,
+          vue: `<template><img class="  b  a  " /></template>`,
+          vueOutput: `<template><img class="b a" /></template>`
         },
         {
           errors: 1,
-          html: "<div class='  b  a  ' />",
-          htmlOutput: "<div class='b a' />",
-          jsx: "<div class='  b  a  ' />",
-          jsxOutput: "<div class='b a' />",
-          svelte: "<div class='  b  a  ' />",
-          svelteOutput: "<div class='b a' />",
-          vue: "<template><div class='  b  a  ' /></template>",
-          vueOutput: "<template><div class='b a' /></template>"
+          html: "<img class='  b  a  ' />",
+          htmlOutput: "<img class='b a' />",
+          jsx: "<img class='  b  a  ' />",
+          jsxOutput: "<img class='b a' />",
+          svelte: "<img class='  b  a  ' />",
+          svelteOutput: "<img class='b a' />",
+          vue: "<template><img class='  b  a  ' /></template>",
+          vueOutput: "<template><img class='b a' /></template>"
         },
         {
           errors: 1,
-          jsx: "<div class={`  b  a  `} />",
-          jsxOutput: "<div class={`b a`} />",
-          svelte: "<div class={`  b  a  `} />",
-          svelteOutput: "<div class={`b a`} />"
+          jsx: "<img class={`  b  a  `} />",
+          jsxOutput: "<img class={`b a`} />",
+          svelte: "<img class={`  b  a  `} />",
+          svelteOutput: "<img class={`b a`} />"
         },
         {
           errors: 1,
-          jsx: `<div class={"  b  a  "} />`,
-          jsxOutput: `<div class={"b a"} />`,
-          svelte: `<div class={"  b  a  "} />`,
-          svelteOutput: `<div class={"b a"} />`
+          jsx: `<img class={"  b  a  "} />`,
+          jsxOutput: `<img class={"b a"} />`,
+          svelte: `<img class={"  b  a  "} />`,
+          svelteOutput: `<img class={"b a"} />`
         },
         {
           errors: 1,
-          jsx: "<div class={'  b  a  '} />",
-          jsxOutput: "<div class={'b a'} />",
-          svelte: "<div class={'  b  a  '} />",
-          svelteOutput: "<div class={'b a'} />"
+          jsx: "<img class={'  b  a  '} />",
+          jsxOutput: "<img class={'b a'} />",
+          svelte: "<img class={'  b  a  '} />",
+          svelteOutput: "<img class={'b a'} />"
         }
       ]
     });
@@ -102,10 +102,10 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: "<div class={`  b  a  ${'  c  '}  d  `} />",
-          jsxOutput: "<div class={`b a ${'  c  '} d`} />",
-          svelte: "<div class={`  b  a  ${'  c  '}  d  `} />",
-          svelteOutput: "<div class={`b a ${'  c  '} d`} />"
+          jsx: "<img class={`  b  a  ${'  c  '}  d  `} />",
+          jsxOutput: "<img class={`b a ${'  c  '} d`} />",
+          svelte: "<img class={`  b  a  ${'  c  '}  d  `} />",
+          svelteOutput: "<img class={`b a ${'  c  '} d`} />"
         }
       ]
     });
@@ -131,14 +131,14 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          html: `<div class="${dirty}" />`,
-          htmlOutput: `<div class="${clean}" />`,
-          jsx: `<div class={\`${dirty}\`} />`,
-          jsxOutput: `<div class={\`${clean}\`} />`,
-          svelte: `<div class={\`${dirty}\`} />`,
-          svelteOutput: `<div class={\`${clean}\`} />`,
-          vue: `<template><div class="${dirty}" /></template>`,
-          vueOutput: `<template><div class="${clean}" /></template>`
+          html: `<img class="${dirty}" />`,
+          htmlOutput: `<img class="${clean}" />`,
+          jsx: `<img class={\`${dirty}\`} />`,
+          jsxOutput: `<img class={\`${clean}\`} />`,
+          svelte: `<img class={\`${dirty}\`} />`,
+          svelteOutput: `<img class={\`${clean}\`} />`,
+          vue: `<template><img class="${dirty}" /></template>`,
+          vueOutput: `<template><img class="${clean}" /></template>`
         }
       ]
     });
@@ -184,24 +184,24 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          jsx: `<div class={\`${dirtyExpressionAtStart}\`} />`,
-          jsxOutput: `<div class={\`${cleanExpressionAtStart}\`} />`,
-          svelte: `<div class={\`${dirtyExpressionAtStart}\`} />`,
-          svelteOutput: `<div class={\`${cleanExpressionAtStart}\`} />`
+          jsx: `<img class={\`${dirtyExpressionAtStart}\`} />`,
+          jsxOutput: `<img class={\`${cleanExpressionAtStart}\`} />`,
+          svelte: `<img class={\`${dirtyExpressionAtStart}\`} />`,
+          svelteOutput: `<img class={\`${cleanExpressionAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `<div class={\`${dirtyExpressionBetween}\`} />`,
-          jsxOutput: `<div class={\`${cleanExpressionBetween}\`} />`,
-          svelte: `<div class={\`${dirtyExpressionBetween}\`} />`,
-          svelteOutput: `<div class={\`${cleanExpressionBetween}\`} />`
+          jsx: `<img class={\`${dirtyExpressionBetween}\`} />`,
+          jsxOutput: `<img class={\`${cleanExpressionBetween}\`} />`,
+          svelte: `<img class={\`${dirtyExpressionBetween}\`} />`,
+          svelteOutput: `<img class={\`${cleanExpressionBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `<div class={\`${dirtyExpressionAtEnd}\`} />`,
-          jsxOutput: `<div class={\`${cleanExpressionAtEnd}\`} />`,
-          svelte: `<div class={\`${dirtyExpressionAtEnd}\`} />`,
-          svelteOutput: `<div class={\`${cleanExpressionAtEnd}\`} />`
+          jsx: `<img class={\`${dirtyExpressionAtEnd}\`} />`,
+          jsxOutput: `<img class={\`${cleanExpressionAtEnd}\`} />`,
+          svelte: `<img class={\`${dirtyExpressionAtEnd}\`} />`,
+          svelteOutput: `<img class={\`${cleanExpressionAtEnd}\`} />`
         }
       ]
     });
@@ -225,24 +225,24 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<div class={\`${invalidAtStart}\`} />`,
-          jsxOutput: `<div class={\`${validAtStart}\`} />`,
-          svelte: `<div class={\`${invalidAtStart}\`} />`,
-          svelteOutput: `<div class={\`${validAtStart}\`} />`
+          jsx: `<img class={\`${invalidAtStart}\`} />`,
+          jsxOutput: `<img class={\`${validAtStart}\`} />`,
+          svelte: `<img class={\`${invalidAtStart}\`} />`,
+          svelteOutput: `<img class={\`${validAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `<div class={\`${invalidBetween}\`} />`,
-          jsxOutput: `<div class={\`${validBetween}\`} />`,
-          svelte: `<div class={\`${invalidBetween}\`} />`,
-          svelteOutput: `<div class={\`${validBetween}\`} />`
+          jsx: `<img class={\`${invalidBetween}\`} />`,
+          jsxOutput: `<img class={\`${validBetween}\`} />`,
+          svelte: `<img class={\`${invalidBetween}\`} />`,
+          svelteOutput: `<img class={\`${validBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `<div class={\`${invalidAtEnd}\`} />`,
-          jsxOutput: `<div class={\`${validAtEnd}\`} />`,
-          svelte: `<div class={\`${invalidAtEnd}\`} />`,
-          svelteOutput: `<div class={\`${validAtEnd}\`} />`
+          jsx: `<img class={\`${invalidAtEnd}\`} />`,
+          jsxOutput: `<img class={\`${validAtEnd}\`} />`,
+          svelte: `<img class={\`${invalidAtEnd}\`} />`,
+          svelteOutput: `<img class={\`${validAtEnd}\`} />`
         }
       ]
     });
@@ -266,24 +266,24 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<div class={\`${invalidAtStart}\`} />`,
-          jsxOutput: `<div class={\`${validAtStart}\`} />`,
-          svelte: `<div class={\`${invalidAtStart}\`} />`,
-          svelteOutput: `<div class={\`${validAtStart}\`} />`
+          jsx: `<img class={\`${invalidAtStart}\`} />`,
+          jsxOutput: `<img class={\`${validAtStart}\`} />`,
+          svelte: `<img class={\`${invalidAtStart}\`} />`,
+          svelteOutput: `<img class={\`${validAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `<div class={\`${invalidBetween}\`} />`,
-          jsxOutput: `<div class={\`${validBetween}\`} />`,
-          svelte: `<div class={\`${invalidBetween}\`} />`,
-          svelteOutput: `<div class={\`${validBetween}\`} />`
+          jsx: `<img class={\`${invalidBetween}\`} />`,
+          jsxOutput: `<img class={\`${validBetween}\`} />`,
+          svelte: `<img class={\`${invalidBetween}\`} />`,
+          svelteOutput: `<img class={\`${validBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `<div class={\`${invalidAtEnd}\`} />`,
-          jsxOutput: `<div class={\`${validAtEnd}\`} />`,
-          svelte: `<div class={\`${invalidAtEnd}\`} />`,
-          svelteOutput: `<div class={\`${validAtEnd}\`} />`
+          jsx: `<img class={\`${invalidAtEnd}\`} />`,
+          jsxOutput: `<img class={\`${validAtEnd}\`} />`,
+          svelte: `<img class={\`${invalidAtEnd}\`} />`,
+          svelteOutput: `<img class={\`${validAtEnd}\`} />`
         }
       ]
     });
@@ -313,16 +313,16 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `<div class={\`${validSeparateLineAtStart}\`} />`,
-          svelte: `<div class={\`${validSeparateLineAtStart}\`} />`
+          jsx: `<img class={\`${validSeparateLineAtStart}\`} />`,
+          svelte: `<img class={\`${validSeparateLineAtStart}\`} />`
         },
         {
-          jsx: `<div class={\`${validSeparateLineBetween}\`} />`,
-          svelte: `<div class={\`${validSeparateLineBetween}\`} />`
+          jsx: `<img class={\`${validSeparateLineBetween}\`} />`,
+          svelte: `<img class={\`${validSeparateLineBetween}\`} />`
         },
         {
-          jsx: `<div class={\`${validSeparateLineAtEnd}\`} />`,
-          svelte: `<div class={\`${validSeparateLineAtEnd}\`} />`
+          jsx: `<img class={\`${validSeparateLineAtEnd}\`} />`,
+          svelte: `<img class={\`${validSeparateLineAtEnd}\`} />`
         }
       ]
     });
@@ -335,10 +335,10 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 3,
-          jsx: "<div class={`  ${' b '}  a  d  ${'  c  '}  `} />",
-          jsxOutput: "<div class={`${' b '} a d ${'  c  '}`} />",
-          svelte: "<div class={`  ${' b '}  a  d  ${'  c  '}  `} />",
-          svelteOutput: "<div class={`${' b '} a d ${'  c  '}`} />"
+          jsx: "<img class={`  ${' b '}  a  d  ${'  c  '}  `} />",
+          jsxOutput: "<img class={`${' b '} a d ${'  c  '}`} />",
+          svelte: "<img class={`  ${' b '}  a  d  ${'  c  '}  `} />",
+          svelteOutput: "<img class={`${' b '} a d ${'  c  '}`} />"
         }
       ]
     });
@@ -361,54 +361,54 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          html: `<div class="${uncleanedMultilineString}" />`,
-          htmlOutput: `<div class="${cleanedMultilineString}" />`,
-          svelte: `<div class="${uncleanedMultilineString}" />`,
-          svelteOutput: `<div class="${cleanedMultilineString}" />`,
-          vue: `<template><div class="${uncleanedMultilineString}" /></template>`,
-          vueOutput: `<template><div class="${cleanedMultilineString}" /></template>`
+          html: `<img class="${uncleanedMultilineString}" />`,
+          htmlOutput: `<img class="${cleanedMultilineString}" />`,
+          svelte: `<img class="${uncleanedMultilineString}" />`,
+          svelteOutput: `<img class="${cleanedMultilineString}" />`,
+          vue: `<template><img class="${uncleanedMultilineString}" /></template>`,
+          vueOutput: `<template><img class="${cleanedMultilineString}" /></template>`
         },
         {
           errors: 1,
-          html: `<div class='${uncleanedMultilineString}' />`,
-          htmlOutput: `<div class='${cleanedMultilineString}' />`,
-          svelte: `<div class='${uncleanedMultilineString}' />`,
-          svelteOutput: `<div class='${cleanedMultilineString}' />`,
-          vue: `<template><div class='${uncleanedMultilineString}' /></template>`,
-          vueOutput: `<template><div class='${cleanedMultilineString}' /></template>`
+          html: `<img class='${uncleanedMultilineString}' />`,
+          htmlOutput: `<img class='${cleanedMultilineString}' />`,
+          svelte: `<img class='${uncleanedMultilineString}' />`,
+          svelteOutput: `<img class='${cleanedMultilineString}' />`,
+          vue: `<template><img class='${uncleanedMultilineString}' /></template>`,
+          vueOutput: `<template><img class='${cleanedMultilineString}' /></template>`
         },
         {
           errors: 1,
-          jsx: `<div class={\`${uncleanedMultilineString}\`} />`,
-          jsxOutput: `<div class={\`${cleanedMultilineString}\`} />`,
-          svelte: `<div class={\`${uncleanedMultilineString}\`} />`,
-          svelteOutput: `<div class={\`${cleanedMultilineString}\`} />`
+          jsx: `<img class={\`${uncleanedMultilineString}\`} />`,
+          jsxOutput: `<img class={\`${cleanedMultilineString}\`} />`,
+          svelte: `<img class={\`${uncleanedMultilineString}\`} />`,
+          svelteOutput: `<img class={\`${cleanedMultilineString}\`} />`
         },
         {
           errors: 1,
-          html: `<div class='${uncleanedMultilineString}' />`,
-          htmlOutput: `<div class='${cleanedSinglelineString}' />`,
-          jsx: `<div class={\`${uncleanedMultilineString}\`} />`,
-          jsxOutput: `<div class={\`${cleanedSinglelineString}\`} />`,
+          html: `<img class='${uncleanedMultilineString}' />`,
+          htmlOutput: `<img class='${cleanedSinglelineString}' />`,
+          jsx: `<img class={\`${uncleanedMultilineString}\`} />`,
+          jsxOutput: `<img class={\`${cleanedSinglelineString}\`} />`,
           options: [{ allowMultiline: false }],
-          svelte: `<div class={\`${uncleanedMultilineString}\`} />`,
-          svelteOutput: `<div class={\`${cleanedSinglelineString}\`} />`,
-          vue: `<template><div class='${uncleanedMultilineString}' /></template>`,
-          vueOutput: `<template><div class='${cleanedSinglelineString}' /></template>`
+          svelte: `<img class={\`${uncleanedMultilineString}\`} />`,
+          svelteOutput: `<img class={\`${cleanedSinglelineString}\`} />`,
+          vue: `<template><img class='${uncleanedMultilineString}' /></template>`,
+          vueOutput: `<template><img class='${cleanedSinglelineString}' /></template>`
         }
       ],
       valid: [
         {
-          html: `<div class="${cleanedMultilineString}" />`,
-          jsx: `<div class={\`${cleanedMultilineString}\`} />`,
-          svelte: `<div class="${cleanedMultilineString}" />`,
-          vue: `<template><div class="${cleanedMultilineString}" /></template>`
+          html: `<img class="${cleanedMultilineString}" />`,
+          jsx: `<img class={\`${cleanedMultilineString}\`} />`,
+          svelte: `<img class="${cleanedMultilineString}" />`,
+          vue: `<template><img class="${cleanedMultilineString}" /></template>`
         },
         {
-          html: `<div class="${cleanedSinglelineString}" />`,
-          jsx: `<div class="${cleanedSinglelineString}" />`,
-          svelte: `<div class="${cleanedSinglelineString}" />`,
-          vue: `<template><div class="${cleanedSinglelineString}" /></template>`
+          html: `<img class="${cleanedSinglelineString}" />`,
+          jsx: `<img class="${cleanedSinglelineString}" />`,
+          svelte: `<img class="${cleanedSinglelineString}" />`,
+          vue: `<template><img class="${cleanedSinglelineString}" /></template>`
         }
       ]
     });
@@ -437,16 +437,16 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `<div class={\`${validAtStart}\`} />`,
-          svelte: `<div class={\`${validAtStart}\`} />`
+          jsx: `<img class={\`${validAtStart}\`} />`,
+          svelte: `<img class={\`${validAtStart}\`} />`
         },
         {
-          jsx: `<div class={\`${validAround}\`} />`,
-          svelte: `<div class={\`${validAround}\`} />`
+          jsx: `<img class={\`${validAround}\`} />`,
+          svelte: `<img class={\`${validAround}\`} />`
         },
         {
-          jsx: `<div class={\`${validAtEnd}\`} />`,
-          svelte: `<div class={\`${validAtEnd}\`} />`
+          jsx: `<img class={\`${validAtEnd}\`} />`,
+          svelte: `<img class={\`${validAtEnd}\`} />`
         }
       ]
     });
@@ -611,17 +611,17 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 1,
-          jsx: `<div class={\`${dirtyDefinedMultiline}\`} />`,
-          jsxOutput: `<div class={\`${cleanDefinedMultiline}\`} />`,
+          jsx: `<img class={\`${dirtyDefinedMultiline}\`} />`,
+          jsxOutput: `<img class={\`${cleanDefinedMultiline}\`} />`,
           options: [{ callees: ["defined"] }],
-          svelte: `<div class={\`${dirtyDefinedMultiline}\`} />`,
-          svelteOutput: `<div class={\`${cleanDefinedMultiline}\`} />`
+          svelte: `<img class={\`${dirtyDefinedMultiline}\`} />`,
+          svelteOutput: `<img class={\`${cleanDefinedMultiline}\`} />`
         }
       ],
       valid: [
         {
-          jsx: `<div class={\`${dirtyUndefinedMultiline}\`} />`,
-          svelte: `<div class={\`${dirtyUndefinedMultiline}\`} />`
+          jsx: `<img class={\`${dirtyUndefinedMultiline}\`} />`,
+          svelte: `<img class={\`${dirtyUndefinedMultiline}\`} />`
         }
       ]
     });

--- a/src/rules/tailwind-no-unnecessary-whitespace.test.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.test.ts
@@ -1,28 +1,28 @@
 import { createTrimTag, lint, TEST_SYNTAXES } from "tests/utils.js";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 
 import { tailwindNoUnnecessaryWhitespace } from "readable-tailwind:rules:tailwind-no-unnecessary-whitespace.js";
 
 
 describe(tailwindNoUnnecessaryWhitespace.name, () => {
 
-  it("should trim leading and trailing white space in literals", () => expect(
-    void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+  it("should trim leading and trailing white space in literals", () => {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
-          html: "<div class=\"  b  a  \" />",
-          htmlOutput: "<div class=\"b a\" />",
-          jsx: "const Test = () => <div class=\"  b  a  \" />;",
-          jsxOutput: "const Test = () => <div class=\"b a\" />;",
-          svelte: "<div class=\"  b  a  \" />",
-          svelteOutput: "<div class=\"b a\" />",
-          vue: "<template><div class=\"  b  a  \" /></template>",
-          vueOutput: "<template><div class=\"b a\" /></template>"
+          html: `<div class="  b  a  " />`,
+          htmlOutput: `<div class="b a" />`,
+          jsx: `<div class="  b  a  " />`,
+          jsxOutput: `<div class="b a" />`,
+          svelte: `<div class="  b  a  " />`,
+          svelteOutput: `<div class="b a" />`,
+          vue: `<template><div class="  b  a  " /></template>`,
+          vueOutput: `<template><div class="b a" /></template>`
         }
       ]
-    })
-  ).toBeUndefined());
+    });
+  });
 
   it("should collapse empty multiline strings", () => {
     const dirtyEmptyMultilineString = `
@@ -30,45 +30,43 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     `;
     const cleanEmptyMultilineString = "";
 
-    expect(
-      void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
-        invalid: [
-          {
-            errors: 1,
-            html: `<div class="${dirtyEmptyMultilineString}" />`,
-            htmlOutput: `<div class="${cleanEmptyMultilineString}" />`,
-            jsx: `const Test = () => <div class="${dirtyEmptyMultilineString}" />;`,
-            jsxOutput: `const Test = () => <div class="${cleanEmptyMultilineString}" />;`,
-            svelte: `<div class="${dirtyEmptyMultilineString}" />`,
-            svelteOutput: `<div class="${cleanEmptyMultilineString}" />`,
-            vue: `<template><div class="${dirtyEmptyMultilineString}" /></template>`,
-            vueOutput: `<template><div class="${cleanEmptyMultilineString}" /></template>`
-          }
-        ]
-      })
-    ).toBeUndefined();
-  });
-
-  it("should keep the quotes as they are", () => expect(
-    void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
-          html: "<div class=\"  b  a  \" />",
-          htmlOutput: "<div class=\"b a\" />",
-          jsx: "const Test = () => <div class=\"  b  a  \" />;",
-          jsxOutput: "const Test = () => <div class=\"b a\" />;",
-          svelte: "<div class=\"  b  a  \" />",
-          svelteOutput: "<div class=\"b a\" />",
-          vue: "<template><div class=\"  b  a  \" /></template>",
-          vueOutput: "<template><div class=\"b a\" /></template>"
+          html: `<div class="${dirtyEmptyMultilineString}" />`,
+          htmlOutput: `<div class="${cleanEmptyMultilineString}" />`,
+          jsx: `<div class="${dirtyEmptyMultilineString}" />`,
+          jsxOutput: `<div class="${cleanEmptyMultilineString}" />`,
+          svelte: `<div class="${dirtyEmptyMultilineString}" />`,
+          svelteOutput: `<div class="${cleanEmptyMultilineString}" />`,
+          vue: `<template><div class="${dirtyEmptyMultilineString}" /></template>`,
+          vueOutput: `<template><div class="${cleanEmptyMultilineString}" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should keep the quotes as they are", () => {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<div class="  b  a  " />`,
+          htmlOutput: `<div class="b a" />`,
+          jsx: `<div class="  b  a  " />`,
+          jsxOutput: `<div class="b a" />`,
+          svelte: `<div class="  b  a  " />`,
+          svelteOutput: `<div class="b a" />`,
+          vue: `<template><div class="  b  a  " /></template>`,
+          vueOutput: `<template><div class="b a" /></template>`
         },
         {
           errors: 1,
           html: "<div class='  b  a  ' />",
           htmlOutput: "<div class='b a' />",
-          jsx: "const Test = () => <div class='  b  a  ' />;",
-          jsxOutput: "const Test = () => <div class='b a' />;",
+          jsx: "<div class='  b  a  ' />",
+          jsxOutput: "<div class='b a' />",
           svelte: "<div class='  b  a  ' />",
           svelteOutput: "<div class='b a' />",
           vue: "<template><div class='  b  a  ' /></template>",
@@ -76,42 +74,42 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
         },
         {
           errors: 1,
-          jsx: "const Test = () => <div class={`  b  a  `} />;",
-          jsxOutput: "const Test = () => <div class={`b a`} />;",
+          jsx: "<div class={`  b  a  `} />",
+          jsxOutput: "<div class={`b a`} />",
           svelte: "<div class={`  b  a  `} />",
           svelteOutput: "<div class={`b a`} />"
         },
         {
           errors: 1,
-          jsx: "const Test = () => <div class={\"  b  a  \"} />;",
-          jsxOutput: "const Test = () => <div class={\"b a\"} />;",
-          svelte: "<div class={\"  b  a  \"} />",
-          svelteOutput: "<div class={\"b a\"} />"
+          jsx: `<div class={"  b  a  "} />`,
+          jsxOutput: `<div class={"b a"} />`,
+          svelte: `<div class={"  b  a  "} />`,
+          svelteOutput: `<div class={"b a"} />`
         },
         {
           errors: 1,
-          jsx: "const Test = () => <div class={'  b  a  '} />;",
-          jsxOutput: "const Test = () => <div class={'b a'} />;",
+          jsx: "<div class={'  b  a  '} />",
+          jsxOutput: "<div class={'b a'} />",
           svelte: "<div class={'  b  a  '} />",
           svelteOutput: "<div class={'b a'} />"
         }
       ]
-    })
-  ).toBeUndefined());
+    });
+  });
 
-  it("should keep one whitespace around template elements", () => expect(
-    void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+  it("should keep one whitespace around template elements", () => {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 2,
-          jsx: "const Test = () => <div class={`  b  a  ${'  c  '}  d  `} />;",
-          jsxOutput: "const Test = () => <div class={`b a ${'  c  '} d`} />;",
+          jsx: "<div class={`  b  a  ${'  c  '}  d  `} />",
+          jsxOutput: "<div class={`b a ${'  c  '} d`} />",
           svelte: "<div class={`  b  a  ${'  c  '}  d  `} />",
           svelteOutput: "<div class={`b a ${'  c  '} d`} />"
         }
       ]
-    })
-  ).toBeUndefined());
+    });
+  });
 
   it("should keep no whitespace at the end of the line in multiline strings", () => {
 
@@ -129,21 +127,21 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       c
     `;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
           html: `<div class="${dirty}" />`,
           htmlOutput: `<div class="${clean}" />`,
-          jsx: `const Test = () => <div class={\`${dirty}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+          jsx: `<div class={\`${dirty}\`} />`,
+          jsxOutput: `<div class={\`${clean}\`} />`,
           svelte: `<div class={\`${dirty}\`} />`,
           svelteOutput: `<div class={\`${clean}\`} />`,
           vue: `<template><div class="${dirty}" /></template>`,
           vueOutput: `<template><div class="${clean}" /></template>`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -182,31 +180,31 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       ${expression}
     `;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
-          jsx: `const Test = () => <div class={\`${dirtyExpressionAtStart}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${cleanExpressionAtStart}\`} />;`,
+          jsx: `<div class={\`${dirtyExpressionAtStart}\`} />`,
+          jsxOutput: `<div class={\`${cleanExpressionAtStart}\`} />`,
           svelte: `<div class={\`${dirtyExpressionAtStart}\`} />`,
           svelteOutput: `<div class={\`${cleanExpressionAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${dirtyExpressionBetween}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${cleanExpressionBetween}\`} />;`,
+          jsx: `<div class={\`${dirtyExpressionBetween}\`} />`,
+          jsxOutput: `<div class={\`${cleanExpressionBetween}\`} />`,
           svelte: `<div class={\`${dirtyExpressionBetween}\`} />`,
           svelteOutput: `<div class={\`${cleanExpressionBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${dirtyExpressionAtEnd}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${cleanExpressionAtEnd}\`} />;`,
+          jsx: `<div class={\`${dirtyExpressionAtEnd}\`} />`,
+          jsxOutput: `<div class={\`${cleanExpressionAtEnd}\`} />`,
           svelte: `<div class={\`${dirtyExpressionAtEnd}\`} />`,
           svelteOutput: `<div class={\`${cleanExpressionAtEnd}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -223,31 +221,31 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     const invalidAtEnd = `  a  ${expression}  `;
     const validAtEnd = `a ${expression}`;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${invalidAtStart}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${validAtStart}\`} />;`,
+          jsx: `<div class={\`${invalidAtStart}\`} />`,
+          jsxOutput: `<div class={\`${validAtStart}\`} />`,
           svelte: `<div class={\`${invalidAtStart}\`} />`,
           svelteOutput: `<div class={\`${validAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${invalidBetween}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${validBetween}\`} />;`,
+          jsx: `<div class={\`${invalidBetween}\`} />`,
+          jsxOutput: `<div class={\`${validBetween}\`} />`,
           svelte: `<div class={\`${invalidBetween}\`} />`,
           svelteOutput: `<div class={\`${validBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${invalidAtEnd}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${validAtEnd}\`} />;`,
+          jsx: `<div class={\`${invalidAtEnd}\`} />`,
+          jsxOutput: `<div class={\`${validAtEnd}\`} />`,
           svelte: `<div class={\`${invalidAtEnd}\`} />`,
           svelteOutput: `<div class={\`${validAtEnd}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -264,31 +262,31 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     const invalidAtEnd = `  a${expression}  `;
     const validAtEnd = `a${expression}`;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${invalidAtStart}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${validAtStart}\`} />;`,
+          jsx: `<div class={\`${invalidAtStart}\`} />`,
+          jsxOutput: `<div class={\`${validAtStart}\`} />`,
           svelte: `<div class={\`${invalidAtStart}\`} />`,
           svelteOutput: `<div class={\`${validAtStart}\`} />`
         },
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${invalidBetween}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${validBetween}\`} />;`,
+          jsx: `<div class={\`${invalidBetween}\`} />`,
+          jsxOutput: `<div class={\`${validBetween}\`} />`,
           svelte: `<div class={\`${invalidBetween}\`} />`,
           svelteOutput: `<div class={\`${validBetween}\`} />`
         },
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${invalidAtEnd}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${validAtEnd}\`} />;`,
+          jsx: `<div class={\`${invalidAtEnd}\`} />`,
+          jsxOutput: `<div class={\`${validAtEnd}\`} />`,
           svelte: `<div class={\`${invalidAtEnd}\`} />`,
           svelteOutput: `<div class={\`${validAtEnd}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -312,38 +310,39 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       ${expression}
     `;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `const Test = () => <div class={\`${validSeparateLineAtStart}\`} />;`,
+          jsx: `<div class={\`${validSeparateLineAtStart}\`} />`,
           svelte: `<div class={\`${validSeparateLineAtStart}\`} />`
         },
         {
-          jsx: `const Test = () => <div class={\`${validSeparateLineBetween}\`} />;`,
+          jsx: `<div class={\`${validSeparateLineBetween}\`} />`,
           svelte: `<div class={\`${validSeparateLineBetween}\`} />`
         },
         {
-          jsx: `const Test = () => <div class={\`${validSeparateLineAtEnd}\`} />;`,
+          jsx: `<div class={\`${validSeparateLineAtEnd}\`} />`,
           svelte: `<div class={\`${validSeparateLineAtEnd}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
-  it("should remove whitespace around template elements if they are at the beginning or end", () => expect(
-    void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+
+  it("should remove whitespace around template elements if they are at the beginning or end", () => {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 3,
-          jsx: "const Test = () => <div class={`  ${' b '}  a  d  ${'  c  '}  `} />;",
-          jsxOutput: "const Test = () => <div class={`${' b '} a d ${'  c  '}`} />;",
+          jsx: "<div class={`  ${' b '}  a  d  ${'  c  '}  `} />",
+          jsxOutput: "<div class={`${' b '} a d ${'  c  '}`} />",
           svelte: "<div class={`  ${' b '}  a  d  ${'  c  '}  `} />",
           svelteOutput: "<div class={`${' b '} a d ${'  c  '}`} />"
         }
       ]
-    })
-  ).toBeUndefined());
+    });
+  });
 
   it("should remove newlines whenever possible", () => {
     const uncleanedMultilineString = `
@@ -358,7 +357,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
 
     const cleanedSinglelineString = "d c b a";
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
@@ -380,8 +379,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
         },
         {
           errors: 1,
-          jsx: `const Test = () => <div class={\`${uncleanedMultilineString}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${cleanedMultilineString}\`} />;`,
+          jsx: `<div class={\`${uncleanedMultilineString}\`} />`,
+          jsxOutput: `<div class={\`${cleanedMultilineString}\`} />`,
           svelte: `<div class={\`${uncleanedMultilineString}\`} />`,
           svelteOutput: `<div class={\`${cleanedMultilineString}\`} />`
         },
@@ -389,8 +388,8 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           errors: 1,
           html: `<div class='${uncleanedMultilineString}' />`,
           htmlOutput: `<div class='${cleanedSinglelineString}' />`,
-          jsx: `const Test = () => <div class={\`${uncleanedMultilineString}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${cleanedSinglelineString}\`} />;`,
+          jsx: `<div class={\`${uncleanedMultilineString}\`} />`,
+          jsxOutput: `<div class={\`${cleanedSinglelineString}\`} />`,
           options: [{ allowMultiline: false }],
           svelte: `<div class={\`${uncleanedMultilineString}\`} />`,
           svelteOutput: `<div class={\`${cleanedSinglelineString}\`} />`,
@@ -401,18 +400,18 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       valid: [
         {
           html: `<div class="${cleanedMultilineString}" />`,
-          jsx: `const Test = () => <div class={\`${cleanedMultilineString}\`} />;`,
+          jsx: `<div class={\`${cleanedMultilineString}\`} />`,
           svelte: `<div class="${cleanedMultilineString}" />`,
           vue: `<template><div class="${cleanedMultilineString}" /></template>`
         },
         {
           html: `<div class="${cleanedSinglelineString}" />`,
-          jsx: `const Test = () => <div class="${cleanedSinglelineString}" />;`,
+          jsx: `<div class="${cleanedSinglelineString}" />`,
           svelte: `<div class="${cleanedSinglelineString}" />`,
           vue: `<template><div class="${cleanedSinglelineString}" /></template>`
         }
       ]
-    })).toBeUndefined();
+    });
   });
 
   it("should not remove whitespace before in template literal elements", () => {
@@ -435,22 +434,22 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       ${expression}
     `;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `const Test = () => <div class={\`${validAtStart}\`} />;`,
+          jsx: `<div class={\`${validAtStart}\`} />`,
           svelte: `<div class={\`${validAtStart}\`} />`
         },
         {
-          jsx: `const Test = () => <div class={\`${validAround}\`} />;`,
+          jsx: `<div class={\`${validAround}\`} />`,
           svelte: `<div class={\`${validAround}\`} />`
         },
         {
-          jsx: `const Test = () => <div class={\`${validAtEnd}\`} />;`,
+          jsx: `<div class={\`${validAtEnd}\`} />`,
           svelte: `<div class={\`${validAtEnd}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -460,7 +459,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
     const cleanDefined = "defined('f e');";
     const dirtyUndefined = "notDefined(\"  f  e  \");";
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
@@ -481,9 +480,9 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           vue: `<script>${dirtyUndefined}</script>`
         }
       ]
-    })).toBeUndefined();
+    });
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
@@ -504,7 +503,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           vue: `<script>${dirtyUndefined}</script>`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -552,7 +551,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       }
     );`;
 
-    expect(void lint(
+    lint(
       tailwindNoUnnecessaryWhitespace,
       TEST_SYNTAXES,
       {
@@ -580,7 +579,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -608,12 +607,12 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       j i
     `;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
-          jsx: `const Test = () => <div class={\`${dirtyDefinedMultiline}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${cleanDefinedMultiline}\`} />;`,
+          jsx: `<div class={\`${dirtyDefinedMultiline}\`} />`,
+          jsxOutput: `<div class={\`${cleanDefinedMultiline}\`} />`,
           options: [{ callees: ["defined"] }],
           svelte: `<div class={\`${dirtyDefinedMultiline}\`} />`,
           svelteOutput: `<div class={\`${cleanDefinedMultiline}\`} />`
@@ -621,11 +620,11 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       ],
       valid: [
         {
-          jsx: `const Test = () => <div class={\`${dirtyUndefinedMultiline}\`} />;`,
+          jsx: `<div class={\`${dirtyUndefinedMultiline}\`} />`,
           svelte: `<div class={\`${dirtyUndefinedMultiline}\`} />`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -645,7 +644,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       d c
     \`;`;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
@@ -675,7 +674,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           vue: `<script>${dirtyUndefined}</script>`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 
@@ -713,7 +712,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       d c
     \`;`;
 
-    expect(void lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
@@ -774,7 +773,7 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
           vue: `<script>${dirtyUndefined}</script>`
         }
       ]
-    })).toBeUndefined();
+    });
 
   });
 

--- a/src/rules/tailwind-no-unnecessary-whitespace.test.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.test.ts
@@ -63,21 +63,21 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
         },
         {
           errors: 1,
-          html: "<img class='  b  a  ' />",
-          htmlOutput: "<img class='b a' />",
-          jsx: "<img class='  b  a  ' />",
-          jsxOutput: "<img class='b a' />",
-          svelte: "<img class='  b  a  ' />",
-          svelteOutput: "<img class='b a' />",
-          vue: "<template><img class='  b  a  ' /></template>",
-          vueOutput: "<template><img class='b a' /></template>"
+          html: `<img class='  b  a  ' />`,
+          htmlOutput: `<img class='b a' />`,
+          jsx: `<img class='  b  a  ' />`,
+          jsxOutput: `<img class='b a' />`,
+          svelte: `<img class='  b  a  ' />`,
+          svelteOutput: `<img class='b a' />`,
+          vue: `<template><img class='  b  a  ' /></template>`,
+          vueOutput: `<template><img class='b a' /></template>`
         },
         {
           errors: 1,
-          jsx: "<img class={`  b  a  `} />",
-          jsxOutput: "<img class={`b a`} />",
-          svelte: "<img class={`  b  a  `} />",
-          svelteOutput: "<img class={`b a`} />"
+          jsx: `<img class={\`  b  a  \`} />`,
+          jsxOutput: `<img class={\`b a\`} />`,
+          svelte: `<img class={\`  b  a  \`} />`,
+          svelteOutput: `<img class={\`b a\`} />`
         },
         {
           errors: 1,
@@ -88,10 +88,10 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
         },
         {
           errors: 1,
-          jsx: "<img class={'  b  a  '} />",
-          jsxOutput: "<img class={'b a'} />",
-          svelte: "<img class={'  b  a  '} />",
-          svelteOutput: "<img class={'b a'} />"
+          jsx: `<img class={'  b  a  '} />`,
+          jsxOutput: `<img class={'b a'} />`,
+          svelte: `<img class={'  b  a  '} />`,
+          svelteOutput: `<img class={'b a'} />`
         }
       ]
     });
@@ -102,10 +102,10 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: "<img class={`  b  a  ${'  c  '}  d  `} />",
-          jsxOutput: "<img class={`b a ${'  c  '} d`} />",
-          svelte: "<img class={`  b  a  ${'  c  '}  d  `} />",
-          svelteOutput: "<img class={`b a ${'  c  '} d`} />"
+          jsx: `<img class={\`  b  a  \${"  c  "}  d  \`} />`,
+          jsxOutput: `<img class={\`b a \${"  c  "} d\`} />`,
+          svelte: `<img class={\`  b  a  \${"  c  "}  d  \`} />`,
+          svelteOutput: `<img class={\`b a \${"  c  "} d\`} />`
         }
       ]
     });
@@ -335,10 +335,10 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
       invalid: [
         {
           errors: 3,
-          jsx: "<img class={`  ${' b '}  a  d  ${'  c  '}  `} />",
-          jsxOutput: "<img class={`${' b '} a d ${'  c  '}`} />",
-          svelte: "<img class={`  ${' b '}  a  d  ${'  c  '}  `} />",
-          svelteOutput: "<img class={`${' b '} a d ${'  c  '}`} />"
+          jsx: `<img class={\`  \${" b "}  a  d  \${"  c  "}  \`} />`,
+          jsxOutput: `<img class={\`\${" b "} a d \${"  c  "}\`} />`,
+          svelte: `<img class={\`  \${" b "}  a  d  \${"  c  "}  \`} />`,
+          svelteOutput: `<img class={\`\${" b "} a d \${"  c  "}\`} />`
         }
       ]
     });

--- a/src/rules/tailwind-sort-classes.test.ts
+++ b/src/rules/tailwind-sort-classes.test.ts
@@ -1,13 +1,13 @@
 import { lint, TEST_SYNTAXES } from "tests/utils.js";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 
 import { tailwindSortClasses } from "readable-tailwind:rules:tailwind-sort-classes.js";
 
 
 describe(tailwindSortClasses.name, () => {
 
-  it("should sort simple class names in string literals by the defined order", () => expect(
-    void lint(
+  it("should sort simple class names in string literals by the defined order", () => {
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -16,8 +16,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: "<div class=\"b a\" />",
             htmlOutput: "<div class=\"a b\" />",
-            jsx: "const Test = () => <div class=\"b a\" />;",
-            jsxOutput: "const Test = () => <div class=\"a b\" />;",
+            jsx: "<div class=\"b a\" />",
+            jsxOutput: "<div class=\"a b\" />",
             options: [{ order: "asc" }],
             svelte: "<div class=\"b a\" />",
             svelteOutput: "<div class=\"a b\" />",
@@ -28,8 +28,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: "<div class=\"a b\" />",
             htmlOutput: "<div class=\"b a\" />",
-            jsx: "const Test = () => <div class=\"a b\" />;",
-            jsxOutput: "const Test = () => <div class=\"b a\" />;",
+            jsx: "<div class=\"a b\" />",
+            jsxOutput: "<div class=\"b a\" />",
             options: [{ order: "desc" }],
             svelte: "<div class=\"a b\" />",
             svelteOutput: "<div class=\"b a\" />",
@@ -40,8 +40,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: "<div class=\"w-full absolute\" />",
             htmlOutput: "<div class=\"absolute w-full\" />",
-            jsx: "const Test = () => <div class=\"w-full absolute\" />;",
-            jsxOutput: "const Test = () => <div class=\"absolute w-full\" />;",
+            jsx: "<div class=\"w-full absolute\" />",
+            jsxOutput: "<div class=\"absolute w-full\" />",
             options: [{ order: "official" }],
             svelte: "<div class=\"w-full absolute\" />",
             svelteOutput: "<div class=\"absolute w-full\" />",
@@ -52,39 +52,39 @@ describe(tailwindSortClasses.name, () => {
         valid: [
           {
             html: "<div class=\"a b\" />",
-            jsx: "const Test = () => <div class=\"a b\" />;",
+            jsx: "<div class=\"a b\" />",
             options: [{ order: "asc" }],
             svelte: "<div class=\"a b\" />",
             vue: "<template><div class=\"a b\" /></template>"
           },
           {
             html: "div class=\"b a\" />",
-            jsx: "const Test = () => <div class=\"b a\" />;",
+            jsx: "<div class=\"b a\" />",
             options: [{ order: "desc" }],
             svelte: "div class=\"b a\" />",
             vue: "<template><div class=\"b a\" /></template>"
           },
           {
             html: "<div class=\"absolute w-full\" />",
-            jsx: "const Test = () => <div class=\"absolute w-full\" />;",
+            jsx: "<div class=\"absolute w-full\" />",
             options: [{ order: "official" }],
             svelte: "<div class=\"absolute w-full\" />",
             vue: "<template><div class=\"absolute w-full\" /></template>"
           }
         ]
       }
-    )
-  ).toBeUndefined());
+    );
+  });
 
   it("should improve the sorting by grouping all classes with the same modifier together", () => {
-    expect(void lint(tailwindSortClasses, TEST_SYNTAXES, {
+    lint(tailwindSortClasses, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 1,
           html: "<div class=\"c:a a:a b:a a:b c:b b:b\" />",
           htmlOutput: "<div class=\"a:a a:b b:a b:b c:a c:b\" />",
-          jsx: "const Test = () => <div class=\"c:a a:a b:a a:b c:b b:b\" />;",
-          jsxOutput: "const Test = () => <div class=\"a:a a:b b:a b:b c:a c:b\" />;",
+          jsx: "<div class=\"c:a a:a b:a a:b c:b b:b\" />",
+          jsxOutput: "<div class=\"a:a a:b b:a b:b c:a c:b\" />",
           options: [{ order: "improved" }],
           svelte: "<div class=\"c:a a:a b:a a:b c:b b:b\" />",
           svelteOutput: "<div class=\"a:a a:b b:a b:b c:a c:b\" />",
@@ -92,11 +92,11 @@ describe(tailwindSortClasses.name, () => {
           vueOutput: "<template><div class=\"a:a a:b b:a b:b c:a c:b\" /></template>"
         }
       ]
-    })).toBeUndefined();
+    });
   });
 
-  it("should keep the quotes as they are", () => expect(
-    void lint(
+  it("should keep the quotes as they are", () => {
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -105,8 +105,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: "<div class=\"b a\" />",
             htmlOutput: "<div class=\"a b\" />",
-            jsx: "const Test = () => <div class=\"b a\" />;",
-            jsxOutput: "const Test = () => <div class=\"a b\" />;",
+            jsx: "<div class=\"b a\" />",
+            jsxOutput: "<div class=\"a b\" />",
             options: [{ order: "asc" }],
             svelte: "<div class=\"b a\" />",
             svelteOutput: "<div class=\"a b\" />",
@@ -117,8 +117,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: "<div class='b a' />",
             htmlOutput: "<div class='a b' />",
-            jsx: "const Test = () => <div class='b a' />;",
-            jsxOutput: "const Test = () => <div class='a b' />;",
+            jsx: "<div class='b a' />",
+            jsxOutput: "<div class='a b' />",
             options: [{ order: "asc" }],
             svelte: "<div class='b a' />",
             svelteOutput: "<div class='a b' />",
@@ -127,47 +127,47 @@ describe(tailwindSortClasses.name, () => {
           },
           {
             errors: 1,
-            jsx: "const Test = () => <div class={`b a`} />;",
-            jsxOutput: "const Test = () => <div class={`a b`} />;",
+            jsx: "<div class={`b a`} />",
+            jsxOutput: "<div class={`a b`} />",
             options: [{ order: "asc" }],
             svelte: "<div class={`b a`} />",
             svelteOutput: "<div class={`a b`} />"
           },
           {
             errors: 1,
-            jsx: "const Test = () => <div class={\"b a\"} />;",
-            jsxOutput: "const Test = () => <div class={\"a b\"} />;",
+            jsx: "<div class={\"b a\"} />",
+            jsxOutput: "<div class={\"a b\"} />",
             options: [{ order: "asc" }]
           },
           {
             errors: 1,
-            jsx: "const Test = () => <div class={'b a'} />;",
-            jsxOutput: "const Test = () => <div class={'a b'} />;",
+            jsx: "<div class={'b a'} />",
+            jsxOutput: "<div class={'a b'} />",
             options: [{ order: "asc" }]
           }
         ]
       }
-    )
-  ).toBeUndefined());
+    );
+  });
 
-  it("should keep expressions as they are", () => expect(
-    void lint(tailwindSortClasses, TEST_SYNTAXES, {
+  it("should keep expressions as they are", () => {
+    lint(tailwindSortClasses, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: "const Test = () => <div class={true ? \"b a\" : \"c b\"} />;",
+          jsx: "<div class={true ? \"b a\" : \"c b\"} />",
           svelte: "<div class={true ? \"b a\" : \"c b\"} />"
         }
       ]
-    })
-  ).toBeUndefined());
+    });
+  });
 
-  it("should keep expressions where they are", () => expect(
-    void lint(tailwindSortClasses, TEST_SYNTAXES, {
+  it("should keep expressions where they are", () => {
+    lint(tailwindSortClasses, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 2,
-          jsx: "const Test = () => <div class={`c a ${true ? 'e' : 'f'} d b `} />;",
-          jsxOutput: "const Test = () => <div class={`a c ${true ? 'e' : 'f'} b d `} />;",
+          jsx: "<div class={`c a ${true ? 'e' : 'f'} d b `} />",
+          jsxOutput: "<div class={`a c ${true ? 'e' : 'f'} b d `} />",
           options: [{ order: "asc" }],
           svelte: "<div class={`c a ${true ? 'e' : 'f'} d b `} />",
           svelteOutput: "<div class={`a c ${true ? 'e' : 'f'} b d `} />"
@@ -175,12 +175,12 @@ describe(tailwindSortClasses.name, () => {
       ],
       valid: [
         {
-          jsx: "const Test = () => <div class={`a c ${true ? 'e' : 'f'} b `} />;",
+          jsx: "<div class={`a c ${true ? 'e' : 'f'} b `} />",
           svelte: "<div class={`a c ${true ? 'e' : 'f'} b `} />"
         }
       ]
-    })
-  ).toBeUndefined());
+    });
+  });
 
   it("should not rip away sticky classes", () => {
 
@@ -189,19 +189,18 @@ describe(tailwindSortClasses.name, () => {
     const dirty = `c b a${expression}f e d`;
     const clean = `b c a${expression}f d e`;
 
-    expect(void lint(tailwindSortClasses, TEST_SYNTAXES, {
+    lint(tailwindSortClasses, TEST_SYNTAXES, {
       invalid: [
         {
           errors: 2,
-          jsx: `const Test = () => <div class={\`${dirty}\`} />;`,
-          jsxOutput: `const Test = () => <div class={\`${clean}\`} />;`,
+          jsx: `<div class={\`${dirty}\`} />`,
+          jsxOutput: `<div class={\`${clean}\`} />`,
           options: [{ order: "asc" }],
           svelte: `<div class={\`${dirty}\`} />`,
           svelteOutput: `<div class={\`${clean}\`} />`
         }
       ]
-    })).toBeUndefined();
-
+    });
   });
 
   it("should sort multiline strings but keep the whitespace as it is", () => {
@@ -215,63 +214,61 @@ describe(tailwindSortClasses.name, () => {
       c d
     `;
 
-    expect(
-      void lint(
-        tailwindSortClasses,
-        TEST_SYNTAXES,
-        {
-          invalid: [
-            {
-              errors: 1,
-              html: `<div class="${unsortedMultilineString}" />`,
-              htmlOutput: `<div class="${sortedMultilineString}" />`,
-              options: [{ order: "asc" }],
-              svelte: `<div class="${unsortedMultilineString}" />`,
-              svelteOutput: `<div class="${sortedMultilineString}" />`,
-              vue: `<template><div class="${unsortedMultilineString}" /></template>`,
-              vueOutput: `<template><div class="${sortedMultilineString}" /></template>`
-            },
-            {
-              errors: 1,
-              html: `<div class='${unsortedMultilineString}' />`,
-              htmlOutput: `<div class='${sortedMultilineString}' />`,
-              options: [{ order: "asc" }],
-              svelte: `<div class='${unsortedMultilineString}' />`,
-              svelteOutput: `<div class='${sortedMultilineString}' />`,
-              vue: `<template><div class='${unsortedMultilineString}' /></template>`,
-              vueOutput: `<template><div class='${sortedMultilineString}' /></template>`
-            },
-            {
-              errors: 1,
-              jsx: `const Test = () => <div class={\`${unsortedMultilineString}\`} />;`,
-              jsxOutput: `const Test = () => <div class={\`${sortedMultilineString}\`} />;`,
-              options: [{ order: "asc" }],
-              svelte: `<div class={\`${unsortedMultilineString}\`} />`,
-              svelteOutput: `<div class={\`${sortedMultilineString}\`} />`
-            }
-          ],
-          valid: [
-            {
-              html: `<div class="${sortedMultilineString}" />`,
-              options: [{ order: "asc" }],
-              svelte: `<div class="${sortedMultilineString}" />`,
-              vue: `<template><div class="${sortedMultilineString}" /></template>`
-            },
-            {
-              html: `<div class='${sortedMultilineString}' />`,
-              options: [{ order: "asc" }],
-              svelte: `<div class='${sortedMultilineString}' />`,
-              vue: `<template><div class='${sortedMultilineString}' /></template>`
-            },
-            {
-              jsx: `const Test = () => <div class={\`${sortedMultilineString}\`} />;`,
-              options: [{ order: "asc" }],
-              svelte: `<div class={\`${sortedMultilineString}\`} />`
-            }
-          ]
-        }
-      )
-    ).toBeUndefined();
+    lint(
+      tailwindSortClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            html: `<div class="${unsortedMultilineString}" />`,
+            htmlOutput: `<div class="${sortedMultilineString}" />`,
+            options: [{ order: "asc" }],
+            svelte: `<div class="${unsortedMultilineString}" />`,
+            svelteOutput: `<div class="${sortedMultilineString}" />`,
+            vue: `<template><div class="${unsortedMultilineString}" /></template>`,
+            vueOutput: `<template><div class="${sortedMultilineString}" /></template>`
+          },
+          {
+            errors: 1,
+            html: `<div class='${unsortedMultilineString}' />`,
+            htmlOutput: `<div class='${sortedMultilineString}' />`,
+            options: [{ order: "asc" }],
+            svelte: `<div class='${unsortedMultilineString}' />`,
+            svelteOutput: `<div class='${sortedMultilineString}' />`,
+            vue: `<template><div class='${unsortedMultilineString}' /></template>`,
+            vueOutput: `<template><div class='${sortedMultilineString}' /></template>`
+          },
+          {
+            errors: 1,
+            jsx: `<div class={\`${unsortedMultilineString}\`} />`,
+            jsxOutput: `<div class={\`${sortedMultilineString}\`} />`,
+            options: [{ order: "asc" }],
+            svelte: `<div class={\`${unsortedMultilineString}\`} />`,
+            svelteOutput: `<div class={\`${sortedMultilineString}\`} />`
+          }
+        ],
+        valid: [
+          {
+            html: `<div class="${sortedMultilineString}" />`,
+            options: [{ order: "asc" }],
+            svelte: `<div class="${sortedMultilineString}" />`,
+            vue: `<template><div class="${sortedMultilineString}" /></template>`
+          },
+          {
+            html: `<div class='${sortedMultilineString}' />`,
+            options: [{ order: "asc" }],
+            svelte: `<div class='${sortedMultilineString}' />`,
+            vue: `<template><div class='${sortedMultilineString}' /></template>`
+          },
+          {
+            jsx: `<div class={\`${sortedMultilineString}\`} />`,
+            options: [{ order: "asc" }],
+            svelte: `<div class={\`${sortedMultilineString}\`} />`
+          }
+        ]
+      }
+    );
   });
 
   it("should sort in string literals in defined call signature arguments", () => {
@@ -280,7 +277,7 @@ describe(tailwindSortClasses.name, () => {
     const cleanDefined = "defined('a b c d');";
     const dirtyUndefined = "notDefined(\"b a d c\");";
 
-    expect(void lint(
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -305,9 +302,9 @@ describe(tailwindSortClasses.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
-    expect(void lint(
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -332,8 +329,7 @@ describe(tailwindSortClasses.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
-
+    );
   });
 
   it("should sort in string literals in call signature arguments matched by a regex", () => {
@@ -380,7 +376,7 @@ describe(tailwindSortClasses.name, () => {
       }
     );`;
 
-    expect(void lint(
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -409,7 +405,7 @@ describe(tailwindSortClasses.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -440,30 +436,30 @@ describe(tailwindSortClasses.name, () => {
       i j
     `;
 
-    expect(void lint(
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
         invalid: [
           {
             errors: 3,
-            jsx: `const Test = () => <div class={\`${dirtyDefinedMultiline}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${cleanDefinedMultiline}\`} />;`,
+            jsx: `<div class={\`${dirtyDefinedMultiline}\`} />`,
+            jsxOutput: `<div class={\`${cleanDefinedMultiline}\`} />`,
             options: [{ callees: ["defined"], order: "asc" }],
             svelte: `<div class={\`${dirtyDefinedMultiline}\`} />`,
             svelteOutput: `<div class={\`${cleanDefinedMultiline}\`} />`
           },
           {
             errors: 2,
-            jsx: `const Test = () => <div class={\`${dirtyUndefinedMultiline}\`} />;`,
-            jsxOutput: `const Test = () => <div class={\`${cleanUndefinedMultiline}\`} />;`,
+            jsx: `<div class={\`${dirtyUndefinedMultiline}\`} />`,
+            jsxOutput: `<div class={\`${cleanUndefinedMultiline}\`} />`,
             options: [{ callees: ["defined"], order: "asc" }],
             svelte: `<div class={\`${dirtyUndefinedMultiline}\`} />`,
             svelteOutput: `<div class={\`${cleanUndefinedMultiline}\`} />`
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -483,7 +479,7 @@ describe(tailwindSortClasses.name, () => {
       c d
     \`;`;
 
-    expect(void lint(
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -518,7 +514,7 @@ describe(tailwindSortClasses.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 
@@ -556,7 +552,7 @@ describe(tailwindSortClasses.name, () => {
       c d
     \`;`;
 
-    expect(void lint(
+    lint(
       tailwindSortClasses,
       TEST_SYNTAXES,
       {
@@ -625,7 +621,7 @@ describe(tailwindSortClasses.name, () => {
           }
         ]
       }
-    )).toBeUndefined();
+    );
 
   });
 

--- a/src/rules/tailwind-sort-classes.test.ts
+++ b/src/rules/tailwind-sort-classes.test.ts
@@ -14,62 +14,62 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 1,
-            html: "<img class=\"b a\" />",
-            htmlOutput: "<img class=\"a b\" />",
-            jsx: "<img class=\"b a\" />",
-            jsxOutput: "<img class=\"a b\" />",
+            html: `<img class="b a" />`,
+            htmlOutput: `<img class="a b" />`,
+            jsx: `<img class="b a" />`,
+            jsxOutput: `<img class="a b" />`,
             options: [{ order: "asc" }],
-            svelte: "<img class=\"b a\" />",
-            svelteOutput: "<img class=\"a b\" />",
-            vue: "<template><img class=\"b a\" /></template>",
-            vueOutput: "<template><img class=\"a b\" /></template>"
+            svelte: `<img class="b a" />`,
+            svelteOutput: `<img class="a b" />`,
+            vue: `<template><img class="b a" /></template>`,
+            vueOutput: `<template><img class="a b" /></template>`
           },
           {
             errors: 1,
-            html: "<img class=\"a b\" />",
-            htmlOutput: "<img class=\"b a\" />",
-            jsx: "<img class=\"a b\" />",
-            jsxOutput: "<img class=\"b a\" />",
+            html: `<img class="a b" />`,
+            htmlOutput: `<img class="b a" />`,
+            jsx: `<img class="a b" />`,
+            jsxOutput: `<img class="b a" />`,
             options: [{ order: "desc" }],
-            svelte: "<img class=\"a b\" />",
-            svelteOutput: "<img class=\"b a\" />",
-            vue: "<template><img class=\"a b\" /></template>",
-            vueOutput: "<template><img class=\"b a\" /></template>"
+            svelte: `<img class="a b" />`,
+            svelteOutput: `<img class="b a" />`,
+            vue: `<template><img class="a b" /></template>`,
+            vueOutput: `<template><img class="b a" /></template>`
           },
           {
             errors: 1,
-            html: "<img class=\"w-full absolute\" />",
-            htmlOutput: "<img class=\"absolute w-full\" />",
-            jsx: "<img class=\"w-full absolute\" />",
-            jsxOutput: "<img class=\"absolute w-full\" />",
+            html: `<img class="w-full absolute" />`,
+            htmlOutput: `<img class="absolute w-full" />`,
+            jsx: `<img class="w-full absolute" />`,
+            jsxOutput: `<img class="absolute w-full" />`,
             options: [{ order: "official" }],
-            svelte: "<img class=\"w-full absolute\" />",
-            svelteOutput: "<img class=\"absolute w-full\" />",
-            vue: "<template><img class=\"w-full absolute\" /></template>",
-            vueOutput: "<template><img class=\"absolute w-full\" /></template>"
+            svelte: `<img class="w-full absolute" />`,
+            svelteOutput: `<img class="absolute w-full" />`,
+            vue: `<template><img class="w-full absolute" /></template>`,
+            vueOutput: `<template><img class="absolute w-full" /></template>`
           }
         ],
         valid: [
           {
-            html: "<img class=\"a b\" />",
-            jsx: "<img class=\"a b\" />",
+            html: `<img class="a b" />`,
+            jsx: `<img class="a b" />`,
             options: [{ order: "asc" }],
-            svelte: "<img class=\"a b\" />",
-            vue: "<template><img class=\"a b\" /></template>"
+            svelte: `<img class="a b" />`,
+            vue: `<template><img class="a b" /></template>`
           },
           {
-            html: "img class=\"b a\" />",
-            jsx: "<img class=\"b a\" />",
+            html: `img class="b a" />`,
+            jsx: `<img class="b a" />`,
             options: [{ order: "desc" }],
-            svelte: "img class=\"b a\" />",
-            vue: "<template><img class=\"b a\" /></template>"
+            svelte: `img class="b a" />`,
+            vue: `<template><img class="b a" /></template>`
           },
           {
-            html: "<img class=\"absolute w-full\" />",
-            jsx: "<img class=\"absolute w-full\" />",
+            html: `<img class="absolute w-full" />`,
+            jsx: `<img class="absolute w-full" />`,
             options: [{ order: "official" }],
-            svelte: "<img class=\"absolute w-full\" />",
-            vue: "<template><img class=\"absolute w-full\" /></template>"
+            svelte: `<img class="absolute w-full" />`,
+            vue: `<template><img class="absolute w-full" /></template>`
           }
         ]
       }
@@ -81,15 +81,15 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 1,
-          html: "<img class=\"c:a a:a b:a a:b c:b b:b\" />",
-          htmlOutput: "<img class=\"a:a a:b b:a b:b c:a c:b\" />",
-          jsx: "<img class=\"c:a a:a b:a a:b c:b b:b\" />",
-          jsxOutput: "<img class=\"a:a a:b b:a b:b c:a c:b\" />",
+          html: `<img class="c:a a:a b:a a:b c:b b:b" />`,
+          htmlOutput: `<img class="a:a a:b b:a b:b c:a c:b" />`,
+          jsx: `<img class="c:a a:a b:a a:b c:b b:b" />`,
+          jsxOutput: `<img class="a:a a:b b:a b:b c:a c:b" />`,
           options: [{ order: "improved" }],
-          svelte: "<img class=\"c:a a:a b:a a:b c:b b:b\" />",
-          svelteOutput: "<img class=\"a:a a:b b:a b:b c:a c:b\" />",
-          vue: "<template><img class=\"c:a a:a b:a a:b c:b b:b\" /></template>",
-          vueOutput: "<template><img class=\"a:a a:b b:a b:b c:a c:b\" /></template>"
+          svelte: `<img class="c:a a:a b:a a:b c:b b:b" />`,
+          svelteOutput: `<img class="a:a a:b b:a b:b c:a c:b" />`,
+          vue: `<template><img class="c:a a:a b:a a:b c:b b:b" /></template>`,
+          vueOutput: `<template><img class="a:a a:b b:a b:b c:a c:b" /></template>`
         }
       ]
     });
@@ -103,46 +103,46 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 1,
-            html: "<img class=\"b a\" />",
-            htmlOutput: "<img class=\"a b\" />",
-            jsx: "<img class=\"b a\" />",
-            jsxOutput: "<img class=\"a b\" />",
+            html: `<img class="b a" />`,
+            htmlOutput: `<img class="a b" />`,
+            jsx: `<img class="b a" />`,
+            jsxOutput: `<img class="a b" />`,
             options: [{ order: "asc" }],
-            svelte: "<img class=\"b a\" />",
-            svelteOutput: "<img class=\"a b\" />",
-            vue: "<template><img class=\"b a\" /></template>",
-            vueOutput: "<template><img class=\"a b\" /></template>"
+            svelte: `<img class="b a" />`,
+            svelteOutput: `<img class="a b" />`,
+            vue: `<template><img class="b a" /></template>`,
+            vueOutput: `<template><img class="a b" /></template>`
           },
           {
             errors: 1,
-            html: "<img class='b a' />",
-            htmlOutput: "<img class='a b' />",
-            jsx: "<img class='b a' />",
-            jsxOutput: "<img class='a b' />",
+            html: `<img class='b a' />`,
+            htmlOutput: `<img class='a b' />`,
+            jsx: `<img class='b a' />`,
+            jsxOutput: `<img class='a b' />`,
             options: [{ order: "asc" }],
-            svelte: "<img class='b a' />",
-            svelteOutput: "<img class='a b' />",
-            vue: "<template><img class='b a' /></template>",
-            vueOutput: "<template><img class='a b' /></template>"
+            svelte: `<img class='b a' />`,
+            svelteOutput: `<img class='a b' />`,
+            vue: `<template><img class='b a' /></template>`,
+            vueOutput: `<template><img class='a b' /></template>`
           },
           {
             errors: 1,
-            jsx: "<img class={`b a`} />",
-            jsxOutput: "<img class={`a b`} />",
+            jsx: `<img class={\`b a\`} />`,
+            jsxOutput: `<img class={\`a b\`} />`,
             options: [{ order: "asc" }],
-            svelte: "<img class={`b a`} />",
-            svelteOutput: "<img class={`a b`} />"
+            svelte: `<img class={\`b a\`} />`,
+            svelteOutput: `<img class={\`a b\`} />`
           },
           {
             errors: 1,
-            jsx: "<img class={\"b a\"} />",
-            jsxOutput: "<img class={\"a b\"} />",
+            jsx: `<img class={"b a"} />`,
+            jsxOutput: `<img class={"a b"} />`,
             options: [{ order: "asc" }]
           },
           {
             errors: 1,
-            jsx: "<img class={'b a'} />",
-            jsxOutput: "<img class={'a b'} />",
+            jsx: `<img class={'b a'} />`,
+            jsxOutput: `<img class={'a b'} />`,
             options: [{ order: "asc" }]
           }
         ]
@@ -154,8 +154,8 @@ describe(tailwindSortClasses.name, () => {
     lint(tailwindSortClasses, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: "<img class={true ? \"b a\" : \"c b\"} />",
-          svelte: "<img class={true ? \"b a\" : \"c b\"} />"
+          jsx: `<img class={true ? "b a" : "c b"} />`,
+          svelte: `<img class={true ? "b a" : "c b"} />`
         }
       ]
     });
@@ -166,17 +166,17 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: "<img class={`c a ${true ? 'e' : 'f'} d b `} />",
-          jsxOutput: "<img class={`a c ${true ? 'e' : 'f'} b d `} />",
+          jsx: `<img class={\`c a \${true ? "e" : "f"} d b \`} />`,
+          jsxOutput: `<img class={\`a c \${true ? "e" : "f"} b d \`} />`,
           options: [{ order: "asc" }],
-          svelte: "<img class={`c a ${true ? 'e' : 'f'} d b `} />",
-          svelteOutput: "<img class={`a c ${true ? 'e' : 'f'} b d `} />"
+          svelte: `<img class={\`c a \${true ? "e" : "f"} d b \`} />`,
+          svelteOutput: `<img class={\`a c \${true ? "e" : "f"} b d \`} />`
         }
       ],
       valid: [
         {
-          jsx: "<img class={`a c ${true ? 'e' : 'f'} b `} />",
-          svelte: "<img class={`a c ${true ? 'e' : 'f'} b `} />"
+          jsx: `<img class={\`a c \${true ? "e" : "f"} b \`} />`,
+          svelte: `<img class={\`a c \${true ? "e" : "f"} b \`} />`
         }
       ]
     });

--- a/src/rules/tailwind-sort-classes.test.ts
+++ b/src/rules/tailwind-sort-classes.test.ts
@@ -14,62 +14,62 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 1,
-            html: "<div class=\"b a\" />",
-            htmlOutput: "<div class=\"a b\" />",
-            jsx: "<div class=\"b a\" />",
-            jsxOutput: "<div class=\"a b\" />",
+            html: "<img class=\"b a\" />",
+            htmlOutput: "<img class=\"a b\" />",
+            jsx: "<img class=\"b a\" />",
+            jsxOutput: "<img class=\"a b\" />",
             options: [{ order: "asc" }],
-            svelte: "<div class=\"b a\" />",
-            svelteOutput: "<div class=\"a b\" />",
-            vue: "<template><div class=\"b a\" /></template>",
-            vueOutput: "<template><div class=\"a b\" /></template>"
+            svelte: "<img class=\"b a\" />",
+            svelteOutput: "<img class=\"a b\" />",
+            vue: "<template><img class=\"b a\" /></template>",
+            vueOutput: "<template><img class=\"a b\" /></template>"
           },
           {
             errors: 1,
-            html: "<div class=\"a b\" />",
-            htmlOutput: "<div class=\"b a\" />",
-            jsx: "<div class=\"a b\" />",
-            jsxOutput: "<div class=\"b a\" />",
+            html: "<img class=\"a b\" />",
+            htmlOutput: "<img class=\"b a\" />",
+            jsx: "<img class=\"a b\" />",
+            jsxOutput: "<img class=\"b a\" />",
             options: [{ order: "desc" }],
-            svelte: "<div class=\"a b\" />",
-            svelteOutput: "<div class=\"b a\" />",
-            vue: "<template><div class=\"a b\" /></template>",
-            vueOutput: "<template><div class=\"b a\" /></template>"
+            svelte: "<img class=\"a b\" />",
+            svelteOutput: "<img class=\"b a\" />",
+            vue: "<template><img class=\"a b\" /></template>",
+            vueOutput: "<template><img class=\"b a\" /></template>"
           },
           {
             errors: 1,
-            html: "<div class=\"w-full absolute\" />",
-            htmlOutput: "<div class=\"absolute w-full\" />",
-            jsx: "<div class=\"w-full absolute\" />",
-            jsxOutput: "<div class=\"absolute w-full\" />",
+            html: "<img class=\"w-full absolute\" />",
+            htmlOutput: "<img class=\"absolute w-full\" />",
+            jsx: "<img class=\"w-full absolute\" />",
+            jsxOutput: "<img class=\"absolute w-full\" />",
             options: [{ order: "official" }],
-            svelte: "<div class=\"w-full absolute\" />",
-            svelteOutput: "<div class=\"absolute w-full\" />",
-            vue: "<template><div class=\"w-full absolute\" /></template>",
-            vueOutput: "<template><div class=\"absolute w-full\" /></template>"
+            svelte: "<img class=\"w-full absolute\" />",
+            svelteOutput: "<img class=\"absolute w-full\" />",
+            vue: "<template><img class=\"w-full absolute\" /></template>",
+            vueOutput: "<template><img class=\"absolute w-full\" /></template>"
           }
         ],
         valid: [
           {
-            html: "<div class=\"a b\" />",
-            jsx: "<div class=\"a b\" />",
+            html: "<img class=\"a b\" />",
+            jsx: "<img class=\"a b\" />",
             options: [{ order: "asc" }],
-            svelte: "<div class=\"a b\" />",
-            vue: "<template><div class=\"a b\" /></template>"
+            svelte: "<img class=\"a b\" />",
+            vue: "<template><img class=\"a b\" /></template>"
           },
           {
-            html: "div class=\"b a\" />",
-            jsx: "<div class=\"b a\" />",
+            html: "img class=\"b a\" />",
+            jsx: "<img class=\"b a\" />",
             options: [{ order: "desc" }],
-            svelte: "div class=\"b a\" />",
-            vue: "<template><div class=\"b a\" /></template>"
+            svelte: "img class=\"b a\" />",
+            vue: "<template><img class=\"b a\" /></template>"
           },
           {
-            html: "<div class=\"absolute w-full\" />",
-            jsx: "<div class=\"absolute w-full\" />",
+            html: "<img class=\"absolute w-full\" />",
+            jsx: "<img class=\"absolute w-full\" />",
             options: [{ order: "official" }],
-            svelte: "<div class=\"absolute w-full\" />",
-            vue: "<template><div class=\"absolute w-full\" /></template>"
+            svelte: "<img class=\"absolute w-full\" />",
+            vue: "<template><img class=\"absolute w-full\" /></template>"
           }
         ]
       }
@@ -81,15 +81,15 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 1,
-          html: "<div class=\"c:a a:a b:a a:b c:b b:b\" />",
-          htmlOutput: "<div class=\"a:a a:b b:a b:b c:a c:b\" />",
-          jsx: "<div class=\"c:a a:a b:a a:b c:b b:b\" />",
-          jsxOutput: "<div class=\"a:a a:b b:a b:b c:a c:b\" />",
+          html: "<img class=\"c:a a:a b:a a:b c:b b:b\" />",
+          htmlOutput: "<img class=\"a:a a:b b:a b:b c:a c:b\" />",
+          jsx: "<img class=\"c:a a:a b:a a:b c:b b:b\" />",
+          jsxOutput: "<img class=\"a:a a:b b:a b:b c:a c:b\" />",
           options: [{ order: "improved" }],
-          svelte: "<div class=\"c:a a:a b:a a:b c:b b:b\" />",
-          svelteOutput: "<div class=\"a:a a:b b:a b:b c:a c:b\" />",
-          vue: "<template><div class=\"c:a a:a b:a a:b c:b b:b\" /></template>",
-          vueOutput: "<template><div class=\"a:a a:b b:a b:b c:a c:b\" /></template>"
+          svelte: "<img class=\"c:a a:a b:a a:b c:b b:b\" />",
+          svelteOutput: "<img class=\"a:a a:b b:a b:b c:a c:b\" />",
+          vue: "<template><img class=\"c:a a:a b:a a:b c:b b:b\" /></template>",
+          vueOutput: "<template><img class=\"a:a a:b b:a b:b c:a c:b\" /></template>"
         }
       ]
     });
@@ -103,46 +103,46 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 1,
-            html: "<div class=\"b a\" />",
-            htmlOutput: "<div class=\"a b\" />",
-            jsx: "<div class=\"b a\" />",
-            jsxOutput: "<div class=\"a b\" />",
+            html: "<img class=\"b a\" />",
+            htmlOutput: "<img class=\"a b\" />",
+            jsx: "<img class=\"b a\" />",
+            jsxOutput: "<img class=\"a b\" />",
             options: [{ order: "asc" }],
-            svelte: "<div class=\"b a\" />",
-            svelteOutput: "<div class=\"a b\" />",
-            vue: "<template><div class=\"b a\" /></template>",
-            vueOutput: "<template><div class=\"a b\" /></template>"
+            svelte: "<img class=\"b a\" />",
+            svelteOutput: "<img class=\"a b\" />",
+            vue: "<template><img class=\"b a\" /></template>",
+            vueOutput: "<template><img class=\"a b\" /></template>"
           },
           {
             errors: 1,
-            html: "<div class='b a' />",
-            htmlOutput: "<div class='a b' />",
-            jsx: "<div class='b a' />",
-            jsxOutput: "<div class='a b' />",
+            html: "<img class='b a' />",
+            htmlOutput: "<img class='a b' />",
+            jsx: "<img class='b a' />",
+            jsxOutput: "<img class='a b' />",
             options: [{ order: "asc" }],
-            svelte: "<div class='b a' />",
-            svelteOutput: "<div class='a b' />",
-            vue: "<template><div class='b a' /></template>",
-            vueOutput: "<template><div class='a b' /></template>"
+            svelte: "<img class='b a' />",
+            svelteOutput: "<img class='a b' />",
+            vue: "<template><img class='b a' /></template>",
+            vueOutput: "<template><img class='a b' /></template>"
           },
           {
             errors: 1,
-            jsx: "<div class={`b a`} />",
-            jsxOutput: "<div class={`a b`} />",
+            jsx: "<img class={`b a`} />",
+            jsxOutput: "<img class={`a b`} />",
             options: [{ order: "asc" }],
-            svelte: "<div class={`b a`} />",
-            svelteOutput: "<div class={`a b`} />"
+            svelte: "<img class={`b a`} />",
+            svelteOutput: "<img class={`a b`} />"
           },
           {
             errors: 1,
-            jsx: "<div class={\"b a\"} />",
-            jsxOutput: "<div class={\"a b\"} />",
+            jsx: "<img class={\"b a\"} />",
+            jsxOutput: "<img class={\"a b\"} />",
             options: [{ order: "asc" }]
           },
           {
             errors: 1,
-            jsx: "<div class={'b a'} />",
-            jsxOutput: "<div class={'a b'} />",
+            jsx: "<img class={'b a'} />",
+            jsxOutput: "<img class={'a b'} />",
             options: [{ order: "asc" }]
           }
         ]
@@ -154,8 +154,8 @@ describe(tailwindSortClasses.name, () => {
     lint(tailwindSortClasses, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: "<div class={true ? \"b a\" : \"c b\"} />",
-          svelte: "<div class={true ? \"b a\" : \"c b\"} />"
+          jsx: "<img class={true ? \"b a\" : \"c b\"} />",
+          svelte: "<img class={true ? \"b a\" : \"c b\"} />"
         }
       ]
     });
@@ -166,17 +166,17 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: "<div class={`c a ${true ? 'e' : 'f'} d b `} />",
-          jsxOutput: "<div class={`a c ${true ? 'e' : 'f'} b d `} />",
+          jsx: "<img class={`c a ${true ? 'e' : 'f'} d b `} />",
+          jsxOutput: "<img class={`a c ${true ? 'e' : 'f'} b d `} />",
           options: [{ order: "asc" }],
-          svelte: "<div class={`c a ${true ? 'e' : 'f'} d b `} />",
-          svelteOutput: "<div class={`a c ${true ? 'e' : 'f'} b d `} />"
+          svelte: "<img class={`c a ${true ? 'e' : 'f'} d b `} />",
+          svelteOutput: "<img class={`a c ${true ? 'e' : 'f'} b d `} />"
         }
       ],
       valid: [
         {
-          jsx: "<div class={`a c ${true ? 'e' : 'f'} b `} />",
-          svelte: "<div class={`a c ${true ? 'e' : 'f'} b `} />"
+          jsx: "<img class={`a c ${true ? 'e' : 'f'} b `} />",
+          svelte: "<img class={`a c ${true ? 'e' : 'f'} b `} />"
         }
       ]
     });
@@ -193,11 +193,11 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<div class={\`${dirty}\`} />`,
-          jsxOutput: `<div class={\`${clean}\`} />`,
+          jsx: `<img class={\`${dirty}\`} />`,
+          jsxOutput: `<img class={\`${clean}\`} />`,
           options: [{ order: "asc" }],
-          svelte: `<div class={\`${dirty}\`} />`,
-          svelteOutput: `<div class={\`${clean}\`} />`
+          svelte: `<img class={\`${dirty}\`} />`,
+          svelteOutput: `<img class={\`${clean}\`} />`
         }
       ]
     });
@@ -221,50 +221,50 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 1,
-            html: `<div class="${unsortedMultilineString}" />`,
-            htmlOutput: `<div class="${sortedMultilineString}" />`,
+            html: `<img class="${unsortedMultilineString}" />`,
+            htmlOutput: `<img class="${sortedMultilineString}" />`,
             options: [{ order: "asc" }],
-            svelte: `<div class="${unsortedMultilineString}" />`,
-            svelteOutput: `<div class="${sortedMultilineString}" />`,
-            vue: `<template><div class="${unsortedMultilineString}" /></template>`,
-            vueOutput: `<template><div class="${sortedMultilineString}" /></template>`
+            svelte: `<img class="${unsortedMultilineString}" />`,
+            svelteOutput: `<img class="${sortedMultilineString}" />`,
+            vue: `<template><img class="${unsortedMultilineString}" /></template>`,
+            vueOutput: `<template><img class="${sortedMultilineString}" /></template>`
           },
           {
             errors: 1,
-            html: `<div class='${unsortedMultilineString}' />`,
-            htmlOutput: `<div class='${sortedMultilineString}' />`,
+            html: `<img class='${unsortedMultilineString}' />`,
+            htmlOutput: `<img class='${sortedMultilineString}' />`,
             options: [{ order: "asc" }],
-            svelte: `<div class='${unsortedMultilineString}' />`,
-            svelteOutput: `<div class='${sortedMultilineString}' />`,
-            vue: `<template><div class='${unsortedMultilineString}' /></template>`,
-            vueOutput: `<template><div class='${sortedMultilineString}' /></template>`
+            svelte: `<img class='${unsortedMultilineString}' />`,
+            svelteOutput: `<img class='${sortedMultilineString}' />`,
+            vue: `<template><img class='${unsortedMultilineString}' /></template>`,
+            vueOutput: `<template><img class='${sortedMultilineString}' /></template>`
           },
           {
             errors: 1,
-            jsx: `<div class={\`${unsortedMultilineString}\`} />`,
-            jsxOutput: `<div class={\`${sortedMultilineString}\`} />`,
+            jsx: `<img class={\`${unsortedMultilineString}\`} />`,
+            jsxOutput: `<img class={\`${sortedMultilineString}\`} />`,
             options: [{ order: "asc" }],
-            svelte: `<div class={\`${unsortedMultilineString}\`} />`,
-            svelteOutput: `<div class={\`${sortedMultilineString}\`} />`
+            svelte: `<img class={\`${unsortedMultilineString}\`} />`,
+            svelteOutput: `<img class={\`${sortedMultilineString}\`} />`
           }
         ],
         valid: [
           {
-            html: `<div class="${sortedMultilineString}" />`,
+            html: `<img class="${sortedMultilineString}" />`,
             options: [{ order: "asc" }],
-            svelte: `<div class="${sortedMultilineString}" />`,
-            vue: `<template><div class="${sortedMultilineString}" /></template>`
+            svelte: `<img class="${sortedMultilineString}" />`,
+            vue: `<template><img class="${sortedMultilineString}" /></template>`
           },
           {
-            html: `<div class='${sortedMultilineString}' />`,
+            html: `<img class='${sortedMultilineString}' />`,
             options: [{ order: "asc" }],
-            svelte: `<div class='${sortedMultilineString}' />`,
-            vue: `<template><div class='${sortedMultilineString}' /></template>`
+            svelte: `<img class='${sortedMultilineString}' />`,
+            vue: `<template><img class='${sortedMultilineString}' /></template>`
           },
           {
-            jsx: `<div class={\`${sortedMultilineString}\`} />`,
+            jsx: `<img class={\`${sortedMultilineString}\`} />`,
             options: [{ order: "asc" }],
-            svelte: `<div class={\`${sortedMultilineString}\`} />`
+            svelte: `<img class={\`${sortedMultilineString}\`} />`
           }
         ]
       }
@@ -443,19 +443,19 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 3,
-            jsx: `<div class={\`${dirtyDefinedMultiline}\`} />`,
-            jsxOutput: `<div class={\`${cleanDefinedMultiline}\`} />`,
+            jsx: `<img class={\`${dirtyDefinedMultiline}\`} />`,
+            jsxOutput: `<img class={\`${cleanDefinedMultiline}\`} />`,
             options: [{ callees: ["defined"], order: "asc" }],
-            svelte: `<div class={\`${dirtyDefinedMultiline}\`} />`,
-            svelteOutput: `<div class={\`${cleanDefinedMultiline}\`} />`
+            svelte: `<img class={\`${dirtyDefinedMultiline}\`} />`,
+            svelteOutput: `<img class={\`${cleanDefinedMultiline}\`} />`
           },
           {
             errors: 2,
-            jsx: `<div class={\`${dirtyUndefinedMultiline}\`} />`,
-            jsxOutput: `<div class={\`${cleanUndefinedMultiline}\`} />`,
+            jsx: `<img class={\`${dirtyUndefinedMultiline}\`} />`,
+            jsxOutput: `<img class={\`${cleanUndefinedMultiline}\`} />`,
             options: [{ callees: ["defined"], order: "asc" }],
-            svelte: `<div class={\`${dirtyUndefinedMultiline}\`} />`,
-            svelteOutput: `<div class={\`${cleanUndefinedMultiline}\`} />`
+            svelte: `<img class={\`${dirtyUndefinedMultiline}\`} />`,
+            svelteOutput: `<img class={\`${cleanUndefinedMultiline}\`} />`
           }
         ]
       }

--- a/src/rules/tailwind-sort-classes.test.ts
+++ b/src/rules/tailwind-sort-classes.test.ts
@@ -16,8 +16,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: `<img class="b a" />`,
             htmlOutput: `<img class="a b" />`,
-            jsx: `<img class="b a" />`,
-            jsxOutput: `<img class="a b" />`,
+            jsx: `() => <img class="b a" />`,
+            jsxOutput: `() => <img class="a b" />`,
             options: [{ order: "asc" }],
             svelte: `<img class="b a" />`,
             svelteOutput: `<img class="a b" />`,
@@ -28,8 +28,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: `<img class="a b" />`,
             htmlOutput: `<img class="b a" />`,
-            jsx: `<img class="a b" />`,
-            jsxOutput: `<img class="b a" />`,
+            jsx: `() => <img class="a b" />`,
+            jsxOutput: `() => <img class="b a" />`,
             options: [{ order: "desc" }],
             svelte: `<img class="a b" />`,
             svelteOutput: `<img class="b a" />`,
@@ -40,8 +40,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: `<img class="w-full absolute" />`,
             htmlOutput: `<img class="absolute w-full" />`,
-            jsx: `<img class="w-full absolute" />`,
-            jsxOutput: `<img class="absolute w-full" />`,
+            jsx: `() => <img class="w-full absolute" />`,
+            jsxOutput: `() => <img class="absolute w-full" />`,
             options: [{ order: "official" }],
             svelte: `<img class="w-full absolute" />`,
             svelteOutput: `<img class="absolute w-full" />`,
@@ -52,21 +52,21 @@ describe(tailwindSortClasses.name, () => {
         valid: [
           {
             html: `<img class="a b" />`,
-            jsx: `<img class="a b" />`,
+            jsx: `() => <img class="a b" />`,
             options: [{ order: "asc" }],
             svelte: `<img class="a b" />`,
             vue: `<template><img class="a b" /></template>`
           },
           {
             html: `img class="b a" />`,
-            jsx: `<img class="b a" />`,
+            jsx: `() => <img class="b a" />`,
             options: [{ order: "desc" }],
             svelte: `img class="b a" />`,
             vue: `<template><img class="b a" /></template>`
           },
           {
             html: `<img class="absolute w-full" />`,
-            jsx: `<img class="absolute w-full" />`,
+            jsx: `() => <img class="absolute w-full" />`,
             options: [{ order: "official" }],
             svelte: `<img class="absolute w-full" />`,
             vue: `<template><img class="absolute w-full" /></template>`
@@ -83,8 +83,8 @@ describe(tailwindSortClasses.name, () => {
           errors: 1,
           html: `<img class="c:a a:a b:a a:b c:b b:b" />`,
           htmlOutput: `<img class="a:a a:b b:a b:b c:a c:b" />`,
-          jsx: `<img class="c:a a:a b:a a:b c:b b:b" />`,
-          jsxOutput: `<img class="a:a a:b b:a b:b c:a c:b" />`,
+          jsx: `() => <img class="c:a a:a b:a a:b c:b b:b" />`,
+          jsxOutput: `() => <img class="a:a a:b b:a b:b c:a c:b" />`,
           options: [{ order: "improved" }],
           svelte: `<img class="c:a a:a b:a a:b c:b b:b" />`,
           svelteOutput: `<img class="a:a a:b b:a b:b c:a c:b" />`,
@@ -105,8 +105,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: `<img class="b a" />`,
             htmlOutput: `<img class="a b" />`,
-            jsx: `<img class="b a" />`,
-            jsxOutput: `<img class="a b" />`,
+            jsx: `() => <img class="b a" />`,
+            jsxOutput: `() => <img class="a b" />`,
             options: [{ order: "asc" }],
             svelte: `<img class="b a" />`,
             svelteOutput: `<img class="a b" />`,
@@ -117,8 +117,8 @@ describe(tailwindSortClasses.name, () => {
             errors: 1,
             html: `<img class='b a' />`,
             htmlOutput: `<img class='a b' />`,
-            jsx: `<img class='b a' />`,
-            jsxOutput: `<img class='a b' />`,
+            jsx: `() => <img class='b a' />`,
+            jsxOutput: `() => <img class='a b' />`,
             options: [{ order: "asc" }],
             svelte: `<img class='b a' />`,
             svelteOutput: `<img class='a b' />`,
@@ -127,22 +127,22 @@ describe(tailwindSortClasses.name, () => {
           },
           {
             errors: 1,
-            jsx: `<img class={\`b a\`} />`,
-            jsxOutput: `<img class={\`a b\`} />`,
+            jsx: `() => <img class={\`b a\`} />`,
+            jsxOutput: `() => <img class={\`a b\`} />`,
             options: [{ order: "asc" }],
             svelte: `<img class={\`b a\`} />`,
             svelteOutput: `<img class={\`a b\`} />`
           },
           {
             errors: 1,
-            jsx: `<img class={"b a"} />`,
-            jsxOutput: `<img class={"a b"} />`,
+            jsx: `() => <img class={"b a"} />`,
+            jsxOutput: `() => <img class={"a b"} />`,
             options: [{ order: "asc" }]
           },
           {
             errors: 1,
-            jsx: `<img class={'b a'} />`,
-            jsxOutput: `<img class={'a b'} />`,
+            jsx: `() => <img class={'b a'} />`,
+            jsxOutput: `() => <img class={'a b'} />`,
             options: [{ order: "asc" }]
           }
         ]
@@ -154,7 +154,7 @@ describe(tailwindSortClasses.name, () => {
     lint(tailwindSortClasses, TEST_SYNTAXES, {
       valid: [
         {
-          jsx: `<img class={true ? "b a" : "c b"} />`,
+          jsx: `() => <img class={true ? "b a" : "c b"} />`,
           svelte: `<img class={true ? "b a" : "c b"} />`
         }
       ]
@@ -166,8 +166,8 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<img class={\`c a \${true ? "e" : "f"} d b \`} />`,
-          jsxOutput: `<img class={\`a c \${true ? "e" : "f"} b d \`} />`,
+          jsx: `() => <img class={\`c a \${true ? "e" : "f"} d b \`} />`,
+          jsxOutput: `() => <img class={\`a c \${true ? "e" : "f"} b d \`} />`,
           options: [{ order: "asc" }],
           svelte: `<img class={\`c a \${true ? "e" : "f"} d b \`} />`,
           svelteOutput: `<img class={\`a c \${true ? "e" : "f"} b d \`} />`
@@ -175,7 +175,7 @@ describe(tailwindSortClasses.name, () => {
       ],
       valid: [
         {
-          jsx: `<img class={\`a c \${true ? "e" : "f"} b \`} />`,
+          jsx: `() => <img class={\`a c \${true ? "e" : "f"} b \`} />`,
           svelte: `<img class={\`a c \${true ? "e" : "f"} b \`} />`
         }
       ]
@@ -193,8 +193,8 @@ describe(tailwindSortClasses.name, () => {
       invalid: [
         {
           errors: 2,
-          jsx: `<img class={\`${dirty}\`} />`,
-          jsxOutput: `<img class={\`${clean}\`} />`,
+          jsx: `() => <img class={\`${dirty}\`} />`,
+          jsxOutput: `() => <img class={\`${clean}\`} />`,
           options: [{ order: "asc" }],
           svelte: `<img class={\`${dirty}\`} />`,
           svelteOutput: `<img class={\`${clean}\`} />`
@@ -241,8 +241,8 @@ describe(tailwindSortClasses.name, () => {
           },
           {
             errors: 1,
-            jsx: `<img class={\`${unsortedMultilineString}\`} />`,
-            jsxOutput: `<img class={\`${sortedMultilineString}\`} />`,
+            jsx: `() => <img class={\`${unsortedMultilineString}\`} />`,
+            jsxOutput: `() => <img class={\`${sortedMultilineString}\`} />`,
             options: [{ order: "asc" }],
             svelte: `<img class={\`${unsortedMultilineString}\`} />`,
             svelteOutput: `<img class={\`${sortedMultilineString}\`} />`
@@ -262,7 +262,7 @@ describe(tailwindSortClasses.name, () => {
             vue: `<template><img class='${sortedMultilineString}' /></template>`
           },
           {
-            jsx: `<img class={\`${sortedMultilineString}\`} />`,
+            jsx: `() => <img class={\`${sortedMultilineString}\`} />`,
             options: [{ order: "asc" }],
             svelte: `<img class={\`${sortedMultilineString}\`} />`
           }
@@ -443,16 +443,16 @@ describe(tailwindSortClasses.name, () => {
         invalid: [
           {
             errors: 3,
-            jsx: `<img class={\`${dirtyDefinedMultiline}\`} />`,
-            jsxOutput: `<img class={\`${cleanDefinedMultiline}\`} />`,
+            jsx: `() => <img class={\`${dirtyDefinedMultiline}\`} />`,
+            jsxOutput: `() => <img class={\`${cleanDefinedMultiline}\`} />`,
             options: [{ callees: ["defined"], order: "asc" }],
             svelte: `<img class={\`${dirtyDefinedMultiline}\`} />`,
             svelteOutput: `<img class={\`${cleanDefinedMultiline}\`} />`
           },
           {
             errors: 2,
-            jsx: `<img class={\`${dirtyUndefinedMultiline}\`} />`,
-            jsxOutput: `<img class={\`${cleanUndefinedMultiline}\`} />`,
+            jsx: `() => <img class={\`${dirtyUndefinedMultiline}\`} />`,
+            jsxOutput: `() => <img class={\`${cleanUndefinedMultiline}\`} />`,
             options: [{ callees: ["defined"], order: "asc" }],
             svelte: `<img class={\`${dirtyUndefinedMultiline}\`} />`,
             svelteOutput: `<img class={\`${cleanUndefinedMultiline}\`} />`

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,6 +1,7 @@
 import { RuleTester } from "eslint";
 import { createTag } from "proper-tags";
 import eslintParserSvelte from "svelte-eslint-parser";
+import { afterAll, describe, it } from "vitest";
 import eslintParserVue from "vue-eslint-parser";
 
 import eslintParserHTML from "@html-eslint/parser";
@@ -22,7 +23,6 @@ export const TEST_SYNTAXES = {
     languageOptions: { parser: eslintParserVue }
   }
 } as const;
-
 
 export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, unknown>>(
   eslintRule: Rule,
@@ -52,7 +52,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
   for(const invalid of tests.invalid ?? []){
     for(const syntax of Object.keys(syntaxes)){
 
-      const ruleTester = new RuleTester(syntaxes[syntax]);
+      const ruleTester = createRuleTester(syntaxes[syntax]);
 
       if(!invalid[syntax] || !invalid[`${syntax}Output`]){
         continue;
@@ -63,7 +63,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
           code: invalid[syntax]!,
           errors: invalid.errors,
           options: invalid.options ?? [],
-          output: invalid[`${syntax}Output`]
+          output: invalid[`${syntax}Output`]!
         }],
         valid: []
       });
@@ -73,7 +73,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
   for(const valid of tests.valid ?? []){
     for(const syntax of Object.keys(syntaxes)){
 
-      const ruleTester = new RuleTester(syntaxes[syntax]);
+      const ruleTester = createRuleTester(syntaxes[syntax]);
 
       if(!valid[syntax]){
         continue;
@@ -101,4 +101,19 @@ function customIndentStripTransformer(count: number) {
       return endResult.replace(new RegExp(`^ {${count}}`, "gm"), "");
     }
   };
+}
+
+function createRuleTester(options?: any) {
+  const ruleTester = new RuleTester(options);
+
+  // @ts-expect-error - types are not up to date yet
+  ruleTester.afterAll = afterAll;
+  // @ts-expect-error - types are not up to date yet
+  ruleTester.describe = describe;
+  // @ts-expect-error - types are not up to date yet
+  ruleTester.it = it;
+  // @ts-expect-error - types are not up to date yet
+  ruleTester.itOnly = it.only;
+
+  return ruleTester;
 }


### PR DESCRIPTION
 - use vitest directly
 - allow template literals to avoid unnecessary escaping in most cases and possibly in the future add syntax highlighting
 - simplify jsx tests
 - use valid html element that is self closing