### PR TITLE
fix: remove unnecessary newline after single sticky class

### DIFF
--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -649,6 +649,30 @@ describe(tailwindMultiline.name, () => {
 
   });
 
+  it("should not add an unnecessary new line after a sticky class", () => {
+
+    const trim = createTrimTag(4);
+    const expression = "${true ? ' true ' : ' false '}";
+
+    const multilineWithWithStickyClassAtEnd = trim`
+      ${expression}a
+    `;
+
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            jsx: `() => <img class={\`${multilineWithWithStickyClassAtEnd}\`} />`,
+            options: [{ classesPerLine: 3, indent: 2 }],
+            svelte: `<img class={\`${multilineWithWithStickyClassAtEnd}\`} />`
+          }
+        ]
+      }
+    );
+
+  });
 
   it("should group correctly", () => {
 

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -351,6 +351,11 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
             lines.line.addClass(className);
 
+            // don't add a new line if the first class is also the last
+            if(isLastClass){
+              break;
+            }
+
             if(groupSeparator === "emptyLine"){
               lines.addLine();
             }


### PR DESCRIPTION
Before:

```tsx
<img class={`
  ${true}a

`} />
```

After:
```tsx
<img class={`
  ${true}a
`} />
```