### PR TITLE
fix: prevent inserting new line if the first class is already too long

### DIFF
--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -174,6 +174,37 @@ describe(tailwindMultiline.name, () => {
     );
   });
 
+  it("should not insert an empty line if the first class is already too long", () => {
+
+    const trim = createTrimTag(4);
+
+    const dirty = "this-string-literal-is-exactly-54-characters-in-length";
+    const clean = trim`
+      this-string-literal-is-exactly-54-characters-in-length
+    `;
+
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            html: `<img class="${dirty}" />`,
+            htmlOutput: `<img class="${clean}" />`,
+            jsx: `() => <img class="${dirty}" />`,
+            jsxOutput: `() => <img class={\`${clean}\`} />`,
+            options: [{ printWidth: 50 }],
+            svelte: `<img class="${dirty}" />`,
+            svelteOutput: `<img class="${clean}" />`,
+            vue: `<template><img class="${dirty}" /></template>`,
+            vueOutput: `<template><img class="${clean}" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
   it("should disable the `printWidth` limit when set to `0`", () => {
     lint(
       tailwindMultiline,

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -393,10 +393,16 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
           }
 
           // wrap if the length exceeds the limits
-          if(simulatedLine.length > printWidth && printWidth !== 0 ||
-            lines.line.classCount >= classesPerLine && classesPerLine !== 0){
-            lines.addLine();
-            lines.line.indent();
+          if(
+            simulatedLine.length > printWidth && printWidth !== 0 ||
+            lines.line.classCount >= classesPerLine && classesPerLine !== 0
+          ){
+
+            // but only if the first class if it is not the first class of a group
+            if(!isFirstClass){
+              lines.addLine();
+              lines.line.indent();
+            }
           }
 
           lines.line.addClass(className);


### PR DESCRIPTION
Before:

```tsx
<img class={`

  a-very-long-class-that-exceeds-the-maximum-length
`} />
```

After:
```tsx
<img class={`
  a-very-long-class-that-exceeds-the-maximum-length
`} />
```