### PR TITLE
fix: change quotes in multiline arrays

### DIFF
--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -375,6 +375,30 @@ describe(tailwindMultiline.name, () => {
 
   });
 
+  it("should change the quotes in arrays to backticks", () => {
+
+    const dirtyArray = `["1 2 3 4 5 6 7 8", "9 10 11 12 13 14 15 16"]`;
+    const cleanArray = `[\`\n  1 2 3\n  4 5 6\n  7 8\n\`, \`\n  9 10 11\n  12 13 14\n  15 16\n\`]`;
+
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 2,
+            jsx: `() => <img class={${dirtyArray}} />`,
+            jsxOutput: `() => <img class={${cleanArray}} />`,
+            options: [{ classesPerLine: 3, indent: 2 }],
+            svelte: `<img class={${dirtyArray}} />`,
+            svelteOutput: `<img class={${cleanArray}} />`
+          }
+        ]
+      }
+    );
+
+  });
+
   it("should wrap string literals in call signature arguments matched by a regex", () => {
 
     const dirtyDefined = `defined(

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -230,6 +230,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       if(
         literal.parent.type === "JSXAttribute" ||
         literal.parent.type === "JSXExpressionContainer" ||
+        literal.parent.type === "ArrayExpression" ||
         literal.parent.type === "Property" ||
         literal.parent.type === "CallExpression" ||
         literal.parent.type === "SvelteMustacheTag" ||
@@ -417,6 +418,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       if(
         literal.parent.type === "JSXAttribute" ||
         literal.parent.type === "JSXExpressionContainer" ||
+        literal.parent.type === "ArrayExpression" ||
         literal.parent.type === "Property" ||
         literal.parent.type === "CallExpression" ||
         literal.parent.type === "SvelteMustacheTag" ||


### PR DESCRIPTION
Fixes invalid quotes when arrays get wrapped.

```tsx
// invalid
<img class={["
  a b c
  d e f
"]} />
```

```tsx
// valid
<img class={[`
  a b c
  d e f
`]} />
```