### PR TITLE
fix: escape nested quotes

### DIFF
--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -13,6 +13,7 @@ import { getAttributesByHTMLTag, getLiteralsByHTMLClassAttribute } from "readabl
 import { getAttributesByJSXElement, getLiteralsByJSXClassAttribute } from "readable-tailwind:parsers:jsx.js";
 import { getAttributesBySvelteTag, getLiteralsBySvelteClassAttribute } from "readable-tailwind:parsers:svelte.js";
 import { getAttributesByVueStartTag, getLiteralsByVueClassAttribute } from "readable-tailwind:parsers:vue.js";
+import { escapeNestedQuotes } from "readable-tailwind:utils:quotes.js";
 import { findLineStartPosition, findLiteralStartPosition, splitClasses } from "readable-tailwind:utils:utils.js";
 
 import type { TagNode } from "es-html-parser";
@@ -677,7 +678,10 @@ class Line {
       this.meta.openingQuote,
       this.meta.closingBraces,
       this.meta.leadingWhitespace ?? "",
-      this.join(this.classes),
+      escapeNestedQuotes(
+        this.join(this.classes),
+        this.meta.openingQuote ?? "\""
+      ),
       this.meta.trailingWhitespace ?? "",
       this.meta.openingBraces,
       this.meta.closingQuote

--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -9,6 +9,7 @@ import { getAttributesByHTMLTag, getLiteralsByHTMLClassAttribute } from "readabl
 import { getAttributesByJSXElement, getLiteralsByJSXClassAttribute } from "readable-tailwind:parsers:jsx.js";
 import { getAttributesBySvelteTag, getLiteralsBySvelteClassAttribute } from "readable-tailwind:parsers:svelte.js";
 import { getAttributesByVueStartTag, getLiteralsByVueClassAttribute } from "readable-tailwind:parsers:vue.js";
+import { escapeNestedQuotes } from "readable-tailwind:utils:quotes.js";
 import { splitClasses, splitWhitespaces } from "readable-tailwind:utils:utils.js";
 
 import type { TagNode } from "es-html-parser";
@@ -161,10 +162,15 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
     const classes = splitClassesKeepWhitespace(literal, allowMultiline);
 
+    const escapedClasses = escapeNestedQuotes(
+      classes.join(""),
+      literal.openingQuote ?? "\""
+    );
+
     const fixedClasses = [
       literal.openingQuote ?? "",
       literal.type === "TemplateLiteral" && literal.closingBraces ? literal.closingBraces : "",
-      ...classes,
+      escapedClasses,
       literal.type === "TemplateLiteral" && literal.openingBraces ? literal.openingBraces : "",
       literal.closingQuote ?? ""
     ].join("");

--- a/src/rules/tailwind-sort-classes.ts
+++ b/src/rules/tailwind-sort-classes.ts
@@ -16,6 +16,7 @@ import { getAttributesByHTMLTag, getLiteralsByHTMLClassAttribute } from "readabl
 import { getAttributesByJSXElement, getLiteralsByJSXClassAttribute } from "readable-tailwind:parsers:jsx.js";
 import { getAttributesBySvelteTag, getLiteralsBySvelteClassAttribute } from "readable-tailwind:parsers:svelte.js";
 import { getAttributesByVueStartTag, getLiteralsByVueClassAttribute } from "readable-tailwind:parsers:vue.js";
+import { escapeNestedQuotes } from "readable-tailwind:utils:quotes.js";
 import { splitClasses, splitWhitespaces } from "readable-tailwind:utils:utils.js";
 
 import type { TagNode } from "es-html-parser";
@@ -83,15 +84,23 @@ export const tailwindSortClasses: ESLintRule<Options> = {
             sortedClassChunks[i] && classes.push(sortedClassChunks[i]);
           }
 
-          const fixedClasses = [
-            literal.openingQuote ?? "",
-            literal.type === "TemplateLiteral" && literal.closingBraces ? literal.closingBraces : "",
-            unsortableClasses[0],
-            ...classes,
-            unsortableClasses[1],
-            literal.type === "TemplateLiteral" && literal.openingBraces ? literal.openingBraces : "",
-            literal.closingQuote ?? ""
-          ].join("");
+          const escapedClasses = escapeNestedQuotes(
+            [
+              unsortableClasses[0],
+              ...classes,
+              unsortableClasses[1]
+            ].join(""),
+            literal.openingQuote ?? '"'
+          );
+
+          const fixedClasses =
+            [
+              literal.openingQuote ?? "",
+              literal.type === "TemplateLiteral" && literal.closingBraces ? literal.closingBraces : "",
+              escapedClasses,
+              literal.type === "TemplateLiteral" && literal.openingBraces ? literal.openingBraces : "",
+              literal.closingQuote ?? ""
+            ].join("");
 
           if(literal.raw === fixedClasses){
             continue;

--- a/src/utils/quotes.test.ts
+++ b/src/utils/quotes.test.ts
@@ -1,0 +1,17 @@
+import { equal } from "node:assert";
+import { describe, it } from "node:test";
+
+import { escapeNestedQuotes } from "readable-tailwind:utils:quotes.js";
+
+
+describe("escapeNestedQuotes", () => {
+  it("should escape all nested quotes", () => {
+    equal(escapeNestedQuotes('content-[""]', "\""), 'content-[\\"\\"]');
+    equal(escapeNestedQuotes("content-['']", "'"), "content-[\\'\\']");
+  });
+
+  it("should not escape quotes that are not nested", () => {
+    equal(escapeNestedQuotes('content-[""]', "'"), 'content-[""]');
+    equal(escapeNestedQuotes("content-['']", "\""), "content-['']");
+  });
+});

--- a/src/utils/quotes.ts
+++ b/src/utils/quotes.ts
@@ -1,0 +1,6 @@
+import type { LiteralValueQuotes } from "readable-tailwind:types:ast.js";
+
+
+export function escapeNestedQuotes(content: string, surroundingQuotes: LiteralValueQuotes): string {
+  return content.replace(new RegExp(surroundingQuotes, "g"), `\\${surroundingQuotes}`);
+}


### PR DESCRIPTION
Escapes nested quotes

```tsx
// invalid
<img class="content-[""]" />
```

```tsx
// valid
<img class="content-[\"\"]" />
```

