### PR TITLE
fix: allow call expressions as object values

### DIFF
--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -236,6 +236,9 @@ export function isESObjectKey(node: Node | ESBaseNode & Rule.NodeParentExtension
 export function isInsideObjectValue(node: ESBaseNode & Partial<Rule.NodeParentExtension>) {
   if(!hasESNodeParentExtension(node)){ return false; }
 
+  // Allow call expressions as object values
+  if(isESCallExpression(node)){ return false; }
+
   if(
     node.parent.type === "Property" &&
     node.parent.parent.type === "ObjectExpression" &&

--- a/src/utils/matchers.test.ts
+++ b/src/utils/matchers.test.ts
@@ -461,4 +461,20 @@ describe("matchers", () => {
     });
   });
 
+  it("should still handle callees even when they are object values", () => {
+    lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          jsx: "<img class={{ key: defined('  a b c  ')}} />",
+          jsxOutput: "<img class={{ key: defined('a b c')}} />",
+          options: [{
+            callees: [["defined", [{ match: MatcherType.String }]]],
+            classAttributes: [["class", [{ match: MatcherType.ObjectValue }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 });


### PR DESCRIPTION
Call expression matcher will now override classAttributes matcher:

```tsx
<img class={{ key: someMatcher(' a b c ')}} />
```

```ts
{
  callees: [["defined", [{ match: MatcherType.String }]]],
  classAttributes: [["class", [{ match: MatcherType.ObjectValue }]]]
}
```

When using these options, it will now use the `callees` matcher instead of the `classAttributes` matcher