### PR TITLE
fix: warn in html matchers

### DIFF
--- a/docs/api/defaults.md
+++ b/docs/api/defaults.md
@@ -1,7 +1,7 @@
 
 # Defaults
 
-Every [rule](https://github.com/schoero/eslint-plugin-readable-tailwind/tree/feat/matchers?tab=readme-ov-file#rules) can target multiple class attributes, callee names or variable names.
+Every [rule](../../README.md#rules) can target multiple class attributes, callee names or variable names.
 
 Read the [concepts documentation](../concepts/concepts.md) first to learn why this is important and what different options there are to define where to look for tailwind classes.
 

--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -57,7 +57,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
   The name of the attribute that contains the tailwind classes.
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
-  **Default**: [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
+  **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
 
 <br/>
 

--- a/docs/rules/no-unnecessary-whitespace.md
+++ b/docs/rules/no-unnecessary-whitespace.md
@@ -21,7 +21,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
   The name of the attribute that contains the tailwind classes.
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
-  **Default**: [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
+  **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
 
 <br/>
 

--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -36,7 +36,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
   The name of the attribute that contains the tailwind classes.
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
-  **Default**: [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
+  **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
 
 <br/>
 

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -34,7 +34,6 @@ export const DEFAULT_CALLEE_NAMES = [
 
 export const DEFAULT_ATTRIBUTE_NAMES = [
   "class",
-  "className",
   [
     "class", [
       {

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -33,6 +33,8 @@ export const DEFAULT_CALLEE_NAMES = [
 ] satisfies Callees;
 
 export const DEFAULT_ATTRIBUTE_NAMES = [
+  "class",
+  "className",
   [
     "class", [
       {

--- a/src/parsers/html.ts
+++ b/src/parsers/html.ts
@@ -1,15 +1,40 @@
+import {
+  isClassAttributeMatchers,
+  isClassAttributeName,
+  isClassAttributeRegex
+} from "readable-tailwind:utils:matchers.js";
+import { deduplicateLiterals } from "readable-tailwind:utils:utils.js";
+
 import type { AttributeNode, TagNode } from "es-html-parser";
 import type { Rule } from "eslint";
 
 import type { Literal, QuoteMeta } from "readable-tailwind:types:ast.js";
+import type { ClassAttributes } from "readable-tailwind:types:rule.js";
 
+
+export function getLiteralsByHTMLClassAttribute(ctx: Rule.RuleContext, attribute: AttributeNode, classAttributes: ClassAttributes): Literal[] {
+  const literals = classAttributes.reduce<Literal[]>((literals, classAttribute) => {
+    if(isClassAttributeName(classAttribute)){
+      if(classAttribute.toLowerCase() !== attribute.key.value.toLowerCase()){ return literals; }
+      literals.push(...getLiteralsByHTMLAttributeNode(ctx, attribute));
+    } else if(isClassAttributeRegex(classAttribute)){
+      console.warn("Regex not supported in HTML");
+    } else if(isClassAttributeMatchers(classAttribute)){
+      console.warn("Matchers not supported in HTML");
+    }
+
+    return literals;
+  }, []);
+
+  return deduplicateLiterals(literals);
+
+}
 
 export function getAttributesByHTMLTag(ctx: Rule.RuleContext, node: TagNode): AttributeNode[] {
   return node.attributes;
 }
 
-
-export function getLiteralsByHTMLClassAttribute(ctx: Rule.RuleContext, attribute: AttributeNode): Literal[] {
+export function getLiteralsByHTMLAttributeNode(ctx: Rule.RuleContext, attribute: AttributeNode): Literal[] {
 
   const value = attribute.value;
 

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -120,7 +120,7 @@ export const tailwindMultiline: ESLintRule<Options> = {
           const htmlAttributes = getAttributesByHTMLTag(ctx, htmlTagNode);
 
           for(const htmlAttribute of htmlAttributes){
-            const literals = getLiteralsByHTMLClassAttribute(ctx, htmlAttribute);
+            const literals = getLiteralsByHTMLClassAttribute(ctx, htmlAttribute, classAttributes);
             lintLiterals(ctx, literals);
           }
         }

--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -101,7 +101,7 @@ export const tailwindNoUnnecessaryWhitespace: ESLintRule<Options> = {
           const htmlAttributes = getAttributesByHTMLTag(ctx, htmlTagNode);
 
           for(const htmlAttribute of htmlAttributes){
-            const literals = getLiteralsByHTMLClassAttribute(ctx, htmlAttribute);
+            const literals = getLiteralsByHTMLClassAttribute(ctx, htmlAttribute, classAttributes);
             lintLiterals(ctx, literals);
           }
         }

--- a/src/rules/tailwind-sort-classes.ts
+++ b/src/rules/tailwind-sort-classes.ts
@@ -180,7 +180,7 @@ export const tailwindSortClasses: ESLintRule<Options> = {
           const htmlAttributes = getAttributesByHTMLTag(ctx, htmlNode);
 
           for(const htmlAttribute of htmlAttributes){
-            const literals = getLiteralsByHTMLClassAttribute(ctx, htmlAttribute);
+            const literals = getLiteralsByHTMLClassAttribute(ctx, htmlAttribute, classAttributes);
             lintLiterals(ctx, literals);
           }
         }


### PR DESCRIPTION
Matchers are not compatible with the HTML parser.
This PR adds a `name` attribute for `class` to the defaults and warns if someone tries to use matchers with the html parser.