### PR TITLE
fix: support svelte shorthand syntax

### DIFF
--- a/src/parsers/svelte.test.ts
+++ b/src/parsers/svelte.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+
+import { tailwindSortClasses } from "readable-tailwind:rules:tailwind-sort-classes.js";
+import { lint, TEST_SYNTAXES } from "readable-tailwind:tests:utils.js";
+
+
+describe(tailwindSortClasses.name, () => {
+
+  // #42
+  it("should work with shorthand attributes", () => {
+    lint(tailwindSortClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          options: [{ order: "asc" }],
+          svelte: `<script>let disabled = true;</script><img class="c b a" {disabled} />`,
+          svelteOutput: `<script>let disabled = true;</script><img class="a b c" {disabled} />`
+        }
+      ]
+    });
+  });
+
+});

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -49,10 +49,15 @@ export function getAttributesBySvelteTag(ctx: Rule.RuleContext, node: SvelteStar
 
 export function getLiteralsBySvelteClassAttribute(ctx: Rule.RuleContext, attribute: SvelteAttribute, classAttributes: ClassAttributes): Literal[] {
 
+  // skip shorthand attributes #42
+  if(!Array.isArray(attribute.value)){
+    return [];
+  }
+
   const [value] = attribute.value;
 
   // eslint-disable-next-line eslint-plugin-typescript/no-unnecessary-condition
-  if(!value){ // Empty attribute
+  if(!value){ // empty attribute
     return [];
   }
 


### PR DESCRIPTION
Adds support for svelte attribute shorthand syntax. Fixes #42 

Example: 

```svelte
<script> 
  let shorthandAttribute = "shorthand attributes throw an error"; 
</script>
<button
  class="flex bg-red-500"
  {shorthandAttribute}
/>
```