### PR TITLE
fix: remove unnecessary plugin import in shared config

### DIFF
--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -10,7 +10,6 @@ const pluginName = "readable-tailwind";
 export const config = {
   configs: {
     error: {
-      plugins: [pluginName],
       rules: {
         [`${pluginName}/${tailwindNoUnnecessaryWhitespace.name}`]: "error",
         [`${pluginName}/${tailwindSortClasses.name}`]: "error",

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -17,7 +17,6 @@ export const config = {
       }
     },
     warning: {
-      plugins: [pluginName],
       rules: {
         [`${pluginName}/${tailwindNoUnnecessaryWhitespace.name}`]: "warn",
         [`${pluginName}/${tailwindSortClasses.name}`]: "warn",


### PR DESCRIPTION
Removes plugin definition in shared config which throws an error when used in flat config.
The plugin definition is actually not necessary in the config as the plugin must already be included to be able to use the config.

fixes #41 
