### PR TITLE
feat: new option `preferSingleLine`

### DIFF
--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -24,6 +24,15 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 <br/>
 
+- `preferSingleLine`
+
+  Prefer a single line for different modifiers/variants. When set to `true`, the rule will keep all modifiers/variants on a single line until the line exceeds the `printWidth` or `classesPerLine` limit.
+
+  **Type**: `boolean`  
+  **Default**: `false`  
+
+<br/>
+
 - `indent`
 
   Determines how the code should be indented.
@@ -129,5 +138,19 @@ The following examples show how the rule behaves with different options:
 
   hover:font-bold
   hover:text-opacity-70
+`} />;
+```
+
+```tsx
+// ✅ GOOD: with { preferSingleLine: true, printWidth: 120 }
+<div class="text-black underline focus:font-bold focus:text-opacity-70 hover:font-bold hover:text-opacity-70" />;
+```
+
+```tsx
+// ✅ GOOD: with { preferSingleLine: true, printWidth: 80 }
+<div class={`
+  text-black underline
+  focus:font-bold focus:text-opacity-70
+  hover:font-bold hover:text-opacity-70
 `} />;
 ```

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -109,11 +109,29 @@ describe(tailwindMultiline.name, () => {
     );
   });
 
+  it("should not clean up whitespace in single line strings", () => {
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            html: `<img class="  a  b  c  " />`,
+            jsx: `() => <img class="  a  b  c  " />`,
+            options: [{ printWidth: 60 }],
+            svelte: `<img class="  a  b  c  " />`,
+            vue: `<template><img class="  a  b  c  " /></template>`
+          }
+        ]
+      }
+    );
+  });
+
   it("should wrap and not collapse short lines containing expressions", () => {
 
     const trim = createTrimTag(4);
 
-    const expression = "${true ? ' true ' : ' false '}";
+    const expression = "${true ? 'true' : 'false'}";
 
     const incorrect = trim`
       a ${expression}
@@ -623,7 +641,7 @@ describe(tailwindMultiline.name, () => {
   it("should wrap expressions correctly", () => {
 
     const trim = createTrimTag(4);
-    const expression = "${true ? ' true ' : ' false '}";
+    const expression = "${true ? 'true' : 'false'}";
 
     const singleLineWithExpressionAtBeginning = `${expression} a b c d e f g h `;
     const multilineWithExpressionAtBeginning = trim`
@@ -709,7 +727,7 @@ describe(tailwindMultiline.name, () => {
   it("should not place expressions on a new line when the expression is not surrounded by a space", () => {
 
     const trim = createTrimTag(4);
-    const expression = "${true ? ' true ' : ' false '}";
+    const expression = "${true ? 'true' : 'false'}";
 
     const singleLineWithExpressionAtBeginningWithStickyClassAtEnd = `${expression}a b c d e f g h `;
     const multilineWithExpressionAtBeginningWithStickyClassAtEnd = trim`
@@ -795,7 +813,7 @@ describe(tailwindMultiline.name, () => {
   it("should not add an unnecessary new line after a sticky class", () => {
 
     const trim = createTrimTag(4);
-    const expression = "${true ? ' true ' : ' false '}";
+    const expression = "${true ? 'true' : 'false'}";
 
     const multilineWithWithStickyClassAtEnd = trim`
       ${expression}a

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -817,42 +817,6 @@ describe(tailwindMultiline.name, () => {
 
   });
 
-  it("should group correctly", () => {
-
-    const trim = createTrimTag(4);
-
-    const singleLine = "g-1:a g-1:b g-2:a g-2:b g-3:a g-3:b";
-    const multiline = trim`
-      g-1:a g-1:b
-
-      g-2:a g-2:b
-
-      g-3:a g-3:b
-    `;
-
-    lint(
-      tailwindMultiline,
-      TEST_SYNTAXES,
-      {
-        invalid: [
-          {
-            errors: 1,
-            html: `<img class="${singleLine}" />`,
-            htmlOutput: `<img class="${multiline}" />`,
-            jsx: `() => <img class={\`${singleLine}\`} />`,
-            jsxOutput: `() => <img class={\`${multiline}\`} />`,
-            options: [{ classesPerLine: 3, indent: 2 }],
-            svelte: `<img class="${singleLine}" />`,
-            svelteOutput: `<img class="${multiline}" />`,
-            vue: `<template><img class="${singleLine}" /></template>`,
-            vueOutput: `<template><img class="${multiline}" /></template>`
-          }
-        ]
-      }
-    );
-
-  });
-
   it("should wrap string literals in variable declarations", () => {
 
     const trim = createTrimTag(4);
@@ -1106,6 +1070,97 @@ describe(tailwindMultiline.name, () => {
             jsx: `() => <img class={\`${correct}\`} />`,
             options: [{ group: "never", indent: 2 }],
             svelte: `<img class={\`${correct}\`} />`
+          }
+        ]
+      }
+    );
+
+  });
+
+  it("should be possible to change group separation by emptyLines", () => {
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            html: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            htmlOutput: `<img class="\n  a b c\n\n  g-1:a g-1:b\n\n  g-2:a g-2:b\n" />`,
+            jsx: `() => <img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            jsxOutput: `() => <img class={\`\n  a b c\n\n  g-1:a g-1:b\n\n  g-2:a g-2:b\n\`} />`,
+            options: [{ group: "emptyLine", indent: 2 }],
+            svelte: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            svelteOutput: `<img class="\n  a b c\n\n  g-1:a g-1:b\n\n  g-2:a g-2:b\n" />`,
+            vue: `<template><img class="a b c g-1:a g-1:b g-2:a g-2:b" /></template>`,
+            vueOutput: `<template><img class="\n  a b c\n\n  g-1:a g-1:b\n\n  g-2:a g-2:b\n" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should be possible to change group separation to newLine", () => {
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            html: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            htmlOutput: `<img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" />`,
+            jsx: `() => <img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            jsxOutput: `() => <img class={\`\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n\`} />`,
+            options: [{ group: "newLine", indent: 2 }],
+            svelte: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            svelteOutput: `<img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" />`,
+            vue: `<template><img class="a b c g-1:a g-1:b g-2:a g-2:b" /></template>`,
+            vueOutput: `<template><img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should be wrap groups according to preferSingleLine", () => {
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            html: `<img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" />`,
+            htmlOutput: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            jsx: `() => <img class={\`\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n\`} />`,
+            jsxOutput: `() => <img class={\`a b c g-1:a g-1:b g-2:a g-2:b\`} />`,
+            options: [{ group: "newLine", indent: 2, preferSingleLine: true }],
+            svelte: `<img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" />`,
+            svelteOutput: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            vue: `<template><img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" /></template>`,
+            vueOutput: `<template><img class="a b c g-1:a g-1:b g-2:a g-2:b" /></template>`
+          },
+          {
+            errors: 1,
+            html: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            htmlOutput: `<img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" />`,
+            jsx: `() => <img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            jsxOutput: `() => <img class={\`\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n\`} />`,
+            options: [{ classesPerLine: 6, group: "newLine", indent: 2, preferSingleLine: true, printWidth: 0 }],
+            svelte: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            svelteOutput: `<img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" />`,
+            vue: `<template><img class="a b c g-1:a g-1:b g-2:a g-2:b" /></template>`,
+            vueOutput: `<template><img class="\n  a b c\n  g-1:a g-1:b\n  g-2:a g-2:b\n" /></template>`
+          }
+        ],
+        valid: [
+          {
+            html: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            jsx: `() => <img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            options: [{ group: "newLine", indent: 2, preferSingleLine: true }],
+            svelte: `<img class="a b c g-1:a g-1:b g-2:a g-2:b" />`,
+            vue: `<template><img class="a b c g-1:a g-1:b g-2:a g-2:b" /></template>`
           }
         ]
       }

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -462,9 +462,14 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
     }
 
     // collapse lines if there is no reason for line wrapping or if preferSingleLine is enabled
-    collapse: if(multilineClasses.length === 3 || preferSingleLine){
+    collapse:{
 
-      // disallow collapsing if the original literal was a single line
+      // disallow collapsing if the literal contains expressions or variants, except preferSingleLine is enabled
+      if((groupedClasses?.length !== 1 || literal.openingBraces || literal.closingBraces) && !preferSingleLine){
+        break collapse;
+      }
+
+      // disallow collapsing if the original literal was a single line (keeps original whitespace)
       if(!literal.content.includes(getLineBreaks(lineBreakStyle))){
         break collapse;
       }

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -39,6 +39,7 @@ export type Options = [
     {
       classesPerLine?: number;
       group?: "emptyLine" | "never" | "newLine";
+      preferSingleLine?: boolean;
       indent?: number | "tab";
       lineBreakStyle?: "unix" | "windows";
       printWidth?: number;
@@ -201,6 +202,11 @@ export const tailwindMultiline: ESLintRule<Options> = {
               enum: ["unix", "windows"],
               type: "string"
             },
+            preferSingleLine: {
+              default: getOptions().preferSingleLine,
+              description: "Prefer a single line for the classes. When set to `true`, the rule will keep all classes on a single line until the line exceeds the `printWidth` or `classesPerLine` limit.",
+              type: "boolean"
+            },
             printWidth: {
               default: getOptions().printWidth,
               description: "The maximum line length. Lines are wrapped appropriately to stay within this limit. The value `0` disables line wrapping by `printWidth`.",
@@ -217,7 +223,7 @@ export const tailwindMultiline: ESLintRule<Options> = {
 
 function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
-  const { classesPerLine, group: groupSeparator, indent, lineBreakStyle, printWidth } = getOptions(ctx);
+  const { classesPerLine, group: groupSeparator, indent, lineBreakStyle, preferSingleLine, printWidth } = getOptions(ctx);
 
   for(const literal of literals){
 
@@ -235,7 +241,8 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
     const classChunks = splitClasses(literal.content);
     const groupedClasses = groupClasses(ctx, classChunks);
 
-    const lines = new Lines(ctx, lineStartPosition);
+    const multilineClasses = new Lines(ctx, lineStartPosition);
+    const singlelineClasses = new Lines(ctx, lineStartPosition);
 
     if(literal.openingQuote){
       if(
@@ -249,15 +256,19 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         literal.parent.type === "ConditionalExpression" ||
         literal.parent.type === "LogicalExpression"
       ){
-        lines.line.addMeta({ openingQuote: "`" });
+        multilineClasses.line.addMeta({ openingQuote: "`" });
       } else {
-        lines.line.addMeta({ openingQuote: literal.openingQuote });
+        multilineClasses.line.addMeta({ openingQuote: literal.openingQuote });
       }
+    }
+
+    if(literal.openingQuote && literal.closingQuote){
+      singlelineClasses.line.addMeta({ closingQuote: literal.closingQuote, openingQuote: literal.openingQuote });
     }
 
     leadingTemplateLiteralNewLine: if(literal.type === "TemplateLiteral" && literal.closingBraces){
 
-      lines.line.addMeta({
+      multilineClasses.line.addMeta({
         closingBraces: literal.closingBraces
       });
 
@@ -272,7 +283,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       }
 
       if(groupSeparator === "emptyLine"){
-        lines.addLine();
+        multilineClasses.addLine();
       }
 
       if(
@@ -280,8 +291,8 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         groupSeparator === "newLine" ||
         groupSeparator === "never"
       ){
-        lines.addLine();
-        lines.line.indent();
+        multilineClasses.addLine();
+        multilineClasses.line.indent();
       }
 
     }
@@ -302,20 +313,20 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
           literal.type === "TemplateLiteral" && !literal.closingBraces ||
           literal.type !== "TemplateLiteral"
         )){
-          lines.addLine();
-          lines.line.indent();
+          multilineClasses.addLine();
+          multilineClasses.line.indent();
         }
 
         if(!isFirstGroup){
 
           if(groupSeparator === "emptyLine"){
-            lines.addLine();
+            multilineClasses.addLine();
           }
 
           if(
             groupSeparator === "emptyLine" || groupSeparator === "newLine"){
-            lines.addLine();
-            lines.line.indent();
+            multilineClasses.addLine();
+            multilineClasses.line.indent();
           }
 
         }
@@ -327,7 +338,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
           const className = group.at(i)!;
 
-          const simulatedLine = lines.line
+          const simulatedLine = multilineClasses.line
             .clone()
             .addClass(className)
             .toString();
@@ -336,7 +347,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
           if(isFirstClass && literal.leadingWhitespace === "" &&
             literal.type === "TemplateLiteral" && literal.closingBraces){
 
-            lines.line.addClass(className);
+            multilineClasses.line.addClass(className);
 
             // don't add a new line if the first class is also the last
             if(isLastClass){
@@ -344,12 +355,12 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
             }
 
             if(groupSeparator === "emptyLine"){
-              lines.addLine();
+              multilineClasses.addLine();
             }
 
             if(groupSeparator === "emptyLine" || groupSeparator === "newLine"){
-              lines.addLine();
-              lines.line.indent();
+              multilineClasses.addLine();
+              multilineClasses.line.indent();
             }
 
             continue;
@@ -361,20 +372,20 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
             // skip wrapping for the first class of a group
             if(isFirstClass){
-              lines.line.addClass(className);
+              multilineClasses.line.addClass(className);
               continue;
             }
 
             if(groupSeparator === "emptyLine"){
-              lines.addLine();
+              multilineClasses.addLine();
             }
 
             if(groupSeparator === "emptyLine" || groupSeparator === "newLine"){
-              lines.addLine();
-              lines.line.indent();
+              multilineClasses.addLine();
+              multilineClasses.line.indent();
             }
 
-            lines.line.addClass(className);
+            multilineClasses.line.addClass(className);
 
             continue;
           }
@@ -382,17 +393,18 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
           // wrap if the length exceeds the limits
           if(
             simulatedLine.length > printWidth && printWidth !== 0 ||
-            lines.line.classCount >= classesPerLine && classesPerLine !== 0
+            multilineClasses.line.classCount >= classesPerLine && classesPerLine !== 0
           ){
 
             // but only if it is not the first class of a group or classes are not grouped
             if(!isFirstClass || groupSeparator === "never"){
-              lines.addLine();
-              lines.line.indent();
+              multilineClasses.addLine();
+              multilineClasses.line.indent();
             }
           }
 
-          lines.line.addClass(className);
+          multilineClasses.line.addClass(className);
+          singlelineClasses.line.addClass(className);
 
         }
       }
@@ -403,7 +415,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       // skip newline for sticky classes
       if(literal.trailingWhitespace === "" && groupedClasses){
 
-        lines.line.addMeta({
+        multilineClasses.line.addMeta({
           openingBraces: literal.openingBraces
         });
 
@@ -411,7 +423,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       }
 
       if(groupSeparator === "emptyLine" && groupedClasses){
-        lines.addLine();
+        multilineClasses.addLine();
       }
 
       if(
@@ -419,19 +431,19 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         groupSeparator === "newLine" ||
         groupSeparator === "never"
       ){
-        lines.addLine();
-        lines.line.indent();
+        multilineClasses.addLine();
+        multilineClasses.line.indent();
       }
 
-      lines.line.addMeta({
+      multilineClasses.line.addMeta({
         openingBraces: literal.openingBraces
       });
 
     }
 
     if(literal.closingQuote){
-      lines.addLine();
-      lines.line.indent(lineStartPosition - getIndentation(ctx, indent));
+      multilineClasses.addLine();
+      multilineClasses.line.indent(lineStartPosition - getIndentation(ctx, indent));
 
       if(
         literal.parent.type === "JSXAttribute" ||
@@ -443,27 +455,27 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         literal.parent.type === "VariableDeclarator" ||
         literal.parent.type === "ConditionalExpression" ||
         literal.parent.type === "LogicalExpression"){
-        lines.line.addMeta({ closingQuote: "`" });
+        multilineClasses.line.addMeta({ closingQuote: "`" });
       } else {
-        lines.line.addMeta({ closingQuote: literal.closingQuote });
+        multilineClasses.line.addMeta({ closingQuote: literal.closingQuote });
       }
     }
 
-    // collapse lines if there is no reason for line wrapping
-    collapse: if(lines.length === 3){
+    // collapse lines if there is no reason for line wrapping or if preferSingleLine is enabled
+    collapse: if(multilineClasses.length === 3 || preferSingleLine){
 
       // disallow collapsing if the original literal was a single line
       if(!literal.content.includes(getLineBreaks(lineBreakStyle))){
         break collapse;
       }
 
-      // disallow collapsing if the first line contains more classes than the classesPerLine
-      if(lines.at(1).classCount > classesPerLine && classesPerLine !== 0){
+      // disallow collapsing if the single line contains more classes than the classesPerLine
+      if(singlelineClasses.line.classCount > classesPerLine && classesPerLine !== 0){
         break collapse;
       }
 
-      // disallow collapsing if the first line including the element and all previous characters is longer than the printWidth
-      if(literalStartPosition + lines.at(1).length > printWidth && printWidth !== 0){
+      // disallow collapsing if the single line including the element and all previous characters is longer than the printWidth
+      if(literalStartPosition + singlelineClasses.line.length > printWidth && printWidth !== 0){
         break collapse;
       }
 
@@ -472,13 +484,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         break collapse;
       }
 
-      // add quotes from the first and last line to the second line
-      lines.at(1).addMeta({
-        closingQuote: literal.closingQuote,
-        openingQuote: literal.openingQuote
-      });
-
-      const fixedClasses = lines.at(1).toString(false);
+      const fixedClasses = singlelineClasses.line.toString(false);
 
       if(literal.raw === fixedClasses){
         continue;
@@ -500,14 +506,26 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
     }
 
     // skip if class string was empty
-    if(lines.length === 2){
+    if(multilineClasses.length === 2){
       if(!literal.openingBraces && !literal.closingBraces && literal.content.trim() === ""){
         continue;
       }
     }
 
+    // skip line wrapping if preferSingleLine is enabled and the single line does not exceed the printWidth or classesPerLine
+    if(
+      preferSingleLine &&
+      (
+        literalStartPosition + singlelineClasses.line.length <= printWidth && printWidth !== 0 ||
+        singlelineClasses.line.classCount <= classesPerLine && classesPerLine !== 0
+      ) ||
+      printWidth === 0 && classesPerLine === 0
+    ){
+      continue;
+    }
+
     // skip line wrapping if it is not necessary
-    skip: if(lines.length === 3){
+    skip: if(multilineClasses.length === 3){
 
       // disallow skipping for template literals with braces
       if(literal.type === "TemplateLiteral" && (literal.openingBraces || literal.closingBraces)){
@@ -517,7 +535,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       const openingQuoteLength = literal.openingQuote?.length ?? 0;
       const closingBracesLength = literal.closingBraces?.length ?? 0;
 
-      const firstLineLength = lines
+      const firstLineLength = multilineClasses
         .at(1)
         .toString()
         .trim()
@@ -531,7 +549,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       }
 
       // disallow skipping if the first line contains more classes than the classesPerLine
-      if(lines.at(1).classCount > classesPerLine && classesPerLine !== 0){
+      if(multilineClasses.at(1).classCount > classesPerLine && classesPerLine !== 0){
         break skip;
       }
 
@@ -539,7 +557,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
     }
 
-    const fixedClasses = lines.toString(lineBreakStyle);
+    const fixedClasses = multilineClasses.toString(lineBreakStyle);
 
     if(literal.raw === fixedClasses){
       continue;
@@ -574,6 +592,7 @@ function getOptions(ctx?: Rule.RuleContext) {
   const classesPerLine = options.classesPerLine ?? 0;
   const indent = options.indent ?? 2;
   const group = options.group ?? "emptyLine";
+  const preferSingleLine = options.preferSingleLine ?? false;
 
   const classAttributes = options.classAttributes ?? DEFAULT_ATTRIBUTE_NAMES;
   const callees = options.callees ?? DEFAULT_CALLEE_NAMES;
@@ -587,6 +606,7 @@ function getOptions(ctx?: Rule.RuleContext) {
     group,
     indent,
     lineBreakStyle,
+    preferSingleLine,
     printWidth,
     variables
   };


### PR DESCRIPTION
Prefer a single line for different modifiers/variants. When set to `true`, the rule will keep all modifiers/variants on a single line until the line exceeds the `printWidth` or `classesPerLine` limit.


```tsx
// ❌ BAD
<div class="text-black underline focus:font-bold focus:text-opacity-70 hover:font-bold hover:text-opacity-70" />;
```

```tsx
// ✅ GOOD: with { preferSingleLine: true, printWidth: 120 }
<div class="text-black underline focus:font-bold focus:text-opacity-70 hover:font-bold hover:text-opacity-70" />;
```

```tsx
// ✅ GOOD: with { preferSingleLine: true, printWidth: 80 }
<div class={`
  text-black underline
  focus:font-bold focus:text-opacity-70
  hover:font-bold hover:text-opacity-70
`} />;
```

closes #50 