### PR TITLE
feat: settings

### DIFF
--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -63,7 +63,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes.
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md).
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -72,7 +72,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `callees`
 
-  List of function names which arguments should also get linted.
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -81,7 +81,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `variables`
 
-  List of variable names which initializer should also get linted.
+  List of variable names which initializer should also get linted.  This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`

--- a/docs/rules/no-duplicate-classes.md
+++ b/docs/rules/no-duplicate-classes.md
@@ -8,7 +8,7 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes.
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -17,7 +17,7 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `callees`
 
-  List of function names which arguments should also get linted.
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -26,7 +26,7 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `variables`
 
-  List of variable names which initializer should also get linted.
+  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`

--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -33,7 +33,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes.
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -42,7 +42,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `callees`
 
-  List of function names which arguments should also get linted.
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -51,7 +51,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `variables`
 
-  List of variable names which initializer should also get linted.
+  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -1,5 +1,7 @@
 # Settings
 
+## Table of Contents
+
 - [classAttributes](#classattributes)
 - [callees](#callees)
 - [variables](#variables)

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -1,22 +1,36 @@
-# readable-tailwind/no-unnecessary-whitespace
+# Settings
 
-Disallow unnecessary whitespace in between and around tailwind classes.
+- [classAttributes](#classattributes)
+- [callees](#callees)
+- [variables](#variables)
 
-<br/>
+<br />
+<br />
 
-## Options
+The settings object can be used to globally configure shared options across all rules. Global will always be overridden by rule-specific options.
+To set the settings object, add a `settings` key to the eslint config.
 
-- `allowMultiline`
+<br />
+<br />
 
-  Allow multi-line class declarations.  
-  If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [readable-tailwind/multiline](./multiline.md).
-  
-  **Type**: `boolean`  
-  **Default**: `true`
+```jsonc
+{
+  "plugins": { /* ... */ },
+  "rules": { /* ... */ },
+  "settings": {
+    "readable-tailwind": {
+      "classAttributes": ["class", "className"],
+      "callees": ["cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"],
+      "variables": ["className", "classNames", "classes", "style", "styles"]
+    }
+  }
+}
+```
 
-<br/>
+<br />
+<br />
 
-- `classAttributes`
+### `classAttributes`
 
   The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
 
@@ -25,7 +39,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 
 <br/>
 
-- `callees`
+### `callees`
 
   List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
@@ -34,23 +48,9 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 
 <br/>
 
-- `variables`
+### `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of variable names which initializer should also get linted.  This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
-
-<br/>
-
-## Examples
-
-```tsx
-// ❌ BAD: random unnecessary whitespace
-<div class=" text-black    underline  hover:text-opacity-70   " />;
-```
-
-```tsx
-// ✅ GOOD: only necessary whitespace is remaining
-<div class="text-black underline hover:text-opacity-70"/>;
-```

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -609,9 +609,21 @@ function getOptions(ctx?: Rule.RuleContext) {
   const group = options.group ?? "emptyLine";
   const preferSingleLine = options.preferSingleLine ?? false;
 
-  const classAttributes = options.classAttributes ?? DEFAULT_ATTRIBUTE_NAMES;
-  const callees = options.callees ?? DEFAULT_CALLEE_NAMES;
-  const variables = options.variables ?? DEFAULT_VARIABLE_NAMES;
+  const classAttributes = options.classAttributes ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
+    ctx?.settings["readable-tailwind"]?.classAttributes ??
+    DEFAULT_ATTRIBUTE_NAMES;
+
+  const callees = options.callees ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
+    ctx?.settings["readable-tailwind"]?.callees ??
+    DEFAULT_CALLEE_NAMES;
+
+  const variables = options.variables ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
+    ctx?.settings["readable-tailwind"]?.variables ??
+    DEFAULT_VARIABLE_NAMES;
+
   const lineBreakStyle = options.lineBreakStyle ?? "unix";
 
   return {

--- a/src/rules/tailwind-no-duplicate-classes.ts
+++ b/src/rules/tailwind-no-duplicate-classes.ts
@@ -322,9 +322,20 @@ function getOptions(ctx?: Rule.RuleContext) {
 
   const options: Options[0] = ctx?.options[0] ?? {};
 
-  const classAttributes = options.classAttributes ?? DEFAULT_ATTRIBUTE_NAMES;
-  const callees = options.callees ?? DEFAULT_CALLEE_NAMES;
-  const variables = options.variables ?? DEFAULT_VARIABLE_NAMES;
+  const classAttributes = options.classAttributes ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
+    ctx?.settings["readable-tailwind"]?.classAttributes ??
+    DEFAULT_ATTRIBUTE_NAMES;
+
+  const callees = options.callees ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
+    ctx?.settings["readable-tailwind"]?.callees ??
+    DEFAULT_CALLEE_NAMES;
+
+  const variables = options.variables ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
+    ctx?.settings["readable-tailwind"]?.variables ??
+    DEFAULT_VARIABLE_NAMES;
 
   return {
     callees,

--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -252,10 +252,22 @@ function getOptions(ctx?: Rule.RuleContext) {
 
   const options: Options[0] = ctx?.options[0] ?? {};
 
-  const classAttributes = options.classAttributes ?? DEFAULT_ATTRIBUTE_NAMES;
   const allowMultiline = options.allowMultiline ?? true;
-  const callees = options.callees ?? DEFAULT_CALLEE_NAMES;
-  const variables = options.variables ?? DEFAULT_VARIABLE_NAMES;
+
+  const classAttributes = options.classAttributes ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
+    ctx?.settings["readable-tailwind"]?.classAttributes ??
+    DEFAULT_ATTRIBUTE_NAMES;
+
+  const callees = options.callees ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
+    ctx?.settings["readable-tailwind"]?.callees ??
+    DEFAULT_CALLEE_NAMES;
+
+  const variables = options.variables ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
+    ctx?.settings["readable-tailwind"]?.variables ??
+    DEFAULT_VARIABLE_NAMES;
 
   return {
     allowMultiline,

--- a/src/rules/tailwind-sort-classes.ts
+++ b/src/rules/tailwind-sort-classes.ts
@@ -349,9 +349,21 @@ export function getOptions(ctx?: Rule.RuleContext) {
   const options: Options[0] = ctx?.options[0] ?? {};
 
   const order = options.order ?? "improved";
-  const classAttributes = options.classAttributes ?? DEFAULT_ATTRIBUTE_NAMES;
-  const callees = options.callees ?? DEFAULT_CALLEE_NAMES;
-  const variables = options.variables ?? DEFAULT_VARIABLE_NAMES;
+
+  const classAttributes = options.classAttributes ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
+    ctx?.settings["readable-tailwind"]?.classAttributes ??
+    DEFAULT_ATTRIBUTE_NAMES;
+
+  const callees = options.callees ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
+    ctx?.settings["readable-tailwind"]?.callees ??
+    DEFAULT_CALLEE_NAMES;
+
+  const variables = options.variables ??
+    ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
+    ctx?.settings["readable-tailwind"]?.variables ??
+    DEFAULT_VARIABLE_NAMES;
 
   const tailwindConfig = options.tailwindConfig;
 

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -64,4 +64,5 @@ export interface ESLintRule<Options extends any[] = [any]> {
   name: string;
   rule: Rule.RuleModule;
   options?: Options;
+  settings?: Rule.RuleContext["settings"];
 }

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable eslint-plugin-typescript/naming-convention */
+import { describe, it } from "vitest";
+
+import { tailwindNoDuplicateClasses } from "readable-tailwind:rules:tailwind-no-duplicate-classes.js";
+import { lint, TEST_SYNTAXES } from "readable-tailwind:tests:utils.js";
+
+
+describe("settings", () => {
+
+  it("should use the global settings if provided", () => {
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<img settings="  b  a  c  a  " />`,
+          htmlOutput: `<img settings="  b  a  c    " />`,
+          jsx: `() => <img settings="  b  a  c  a  " />`,
+          jsxOutput: `() => <img settings="  b  a  c    " />`,
+          settings: { "readable-tailwind": { classAttributes: ["settings"] } },
+          svelte: `<img settings="  b  a  c  a  " />`,
+          svelteOutput: `<img settings="  b  a  c    " />`,
+          vue: `<template><img settings="  b  a  c  a  " /></template>`,
+          vueOutput: `<template><img settings="  b  a  c    " /></template>`
+        }
+      ]
+    });
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<img settings="  b  a  c  a  " />`,
+          htmlOutput: `<img settings="  b  a  c    " />`,
+          jsx: `() => <img settings="  b  a  c  a  " />`,
+          jsxOutput: `() => <img settings="  b  a  c    " />`,
+          settings: { "eslint-plugin-readable-tailwind": { classAttributes: ["settings"] } },
+          svelte: `<img settings="  b  a  c  a  " />`,
+          svelteOutput: `<img settings="  b  a  c    " />`,
+          vue: `<template><img settings="  b  a  c  a  " /></template>`,
+          vueOutput: `<template><img settings="  b  a  c    " /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should always use rule options to override settings if provided", () => {
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<img options="  b  a  c  a  " />`,
+          htmlOutput: `<img options="  b  a  c    " />`,
+          jsx: `() => <img options="  b  a  c  a  " />`,
+          jsxOutput: `() => <img options="  b  a  c    " />`,
+          options: [{ classAttributes: ["options"] }],
+          settings: { "readable-tailwind": { classAttributes: ["settings"] } },
+          svelte: `<img options="  b  a  c  a  " />`,
+          svelteOutput: `<img options="  b  a  c    " />`,
+          vue: `<template><img options="  b  a  c  a  " /></template>`,
+          vueOutput: `<template><img options="  b  a  c    " /></template>`
+        }
+      ]
+    });
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<img options="  b  a  c  a  " />`,
+          htmlOutput: `<img options="  b  a  c    " />`,
+          jsx: `() => <img options="  b  a  c  a  " />`,
+          jsxOutput: `() => <img options="  b  a  c    " />`,
+          options: [{ classAttributes: ["options"] }],
+          settings: { "eslint-plugin-readable-tailwind": { classAttributes: ["settings"] } },
+          svelte: `<img options="  b  a  c  a  " />`,
+          svelteOutput: `<img options="  b  a  c    " />`,
+          vue: `<template><img options="  b  a  c  a  " /></template>`,
+          vueOutput: `<template><img options="  b  a  c    " /></template>`
+        }
+      ]
+    });
+  });
+
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -72,7 +72,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
           errors: invalid.errors,
           options: invalid.options ?? [],
           output: invalid[`${syntax}Output`]!,
-          settings: invalid.settings
+          settings: invalid.settings ?? {}
         }],
         valid: []
       });
@@ -93,7 +93,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
         valid: [{
           code: valid[syntax],
           options: valid.options ?? [],
-          settings: valid.settings
+          settings: valid.settings ?? {}
         }]
       });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -9,6 +9,7 @@ import eslintParserVue from "vue-eslint-parser";
 
 import eslintParserHTML from "@html-eslint/parser";
 
+import type { Rule } from "eslint";
 import type { Node as ESNode, Program } from "estree";
 
 import type { ESLintRule, MatcherFunction } from "readable-tailwind:types:rule.js";
@@ -42,6 +43,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
         errors: number;
       } & {
         options?: Rule["options"];
+        settings?: Rule["settings"];
       }
     )[];
     valid?: (
@@ -49,6 +51,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
         [Key in keyof Syntaxes]?: string;
       } & {
         options?: Rule["options"];
+        settings?: Rule["settings"];
       }
     )[];
   }
@@ -57,7 +60,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
   for(const invalid of tests.invalid ?? []){
     for(const syntax of Object.keys(syntaxes)){
 
-      const ruleTester = createRuleTester(syntaxes[syntax]);
+      const ruleTester = createRuleTester(syntaxes[syntax], invalid.settings);
 
       if(!invalid[syntax] || !invalid[`${syntax}Output`]){
         continue;
@@ -68,7 +71,8 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
           code: invalid[syntax],
           errors: invalid.errors,
           options: invalid.options ?? [],
-          output: invalid[`${syntax}Output`]!
+          output: invalid[`${syntax}Output`]!,
+          settings: invalid.settings
         }],
         valid: []
       });
@@ -78,7 +82,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
   for(const valid of tests.valid ?? []){
     for(const syntax of Object.keys(syntaxes)){
 
-      const ruleTester = createRuleTester(syntaxes[syntax]);
+      const ruleTester = createRuleTester(syntaxes[syntax], valid.settings);
 
       if(!valid[syntax]){
         continue;
@@ -88,7 +92,8 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, un
         invalid: [],
         valid: [{
           code: valid[syntax],
-          options: valid.options ?? []
+          options: valid.options ?? [],
+          settings: valid.settings
         }]
       });
 
@@ -141,7 +146,7 @@ function customIndentStripTransformer(count: number) {
   };
 }
 
-function createRuleTester(options?: any) {
+function createRuleTester(options: any, settings?: Rule.RuleContext["settings"]) {
   const ruleTester = new RuleTester(options);
   // @ts-expect-error - missing types
   ruleTester.describe = describe;


### PR DESCRIPTION
Adds support for the settings object to globally configure shared options across all rules. 

```jsonc
{
  "plugins": { /* ... */ },
  "rules": { /* ... */ },
  "settings": {
    "readable-tailwind": {
      "classAttributes": ["class", "className"],
      "callees": ["cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"],
      "variables": ["className", "classNames", "classes", "style", "styles"]
    }
  }
}
```