### PR TITLE
fix: fixing loop

### DIFF
--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -543,8 +543,15 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
     // skip line wrapping if it is not necessary
     skip:{
 
-      // disallow skipping if line count is not 3
-      if(multilineClasses.length !== 3){
+      // disallow skipping if class string contains multiple groups
+      if(groupedClasses && groupedClasses.length > 1){
+        break skip;
+      }
+
+      // disallow skipping if the original literal was longer than the printWidth
+      if(
+        literalStartPosition + singlelineClasses.line.length > printWidth && printWidth !== 0 ||
+        singlelineClasses.line.classCount > classesPerLine && classesPerLine !== 0){
         break skip;
       }
 


### PR DESCRIPTION
when lines wrap on two lines immediately but was the theoretically short enough to not wrap.

```tsx
const Command = React.forwardRef<
    React.ElementRef<typeof CommandPrimitive>,
    React.ComponentPropsWithoutRef<typeof CommandPrimitive>
>(({ className, ...props }, ref) => (
    <CommandPrimitive
        className={cn(
            `flex size-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground`,
            className
        )}
        ref={ref}
        {...props}
    />
))
```

was wrapped to 

```tsx
const Command = React.forwardRef<
    React.ElementRef<typeof CommandPrimitive>,
    React.ComponentPropsWithoutRef<typeof CommandPrimitive>
>(({ className, ...props }, ref) => (
    <CommandPrimitive
        className={cn(
            `
                flex size-full flex-col overflow-hidden rounded-md bg-popover
                text-popover-foreground
            `,
            className
        )}
        ref={ref}
        {...props}
    />
))
```

fixes #57 