### PR TITLE
feat: template literal tags

### DIFF
--- a/docs/api/defaults.md
+++ b/docs/api/defaults.md
@@ -1,7 +1,7 @@
 
 # Defaults
 
-Every [rule](../../README.md#rules) can target multiple class attributes, callee names or variable names.
+Every [rule](../../README.md#rules) can target multiple class attributes, callee names, variable names or template literal tags.
 
 Read the [concepts documentation](../concepts/concepts.md) first to learn why this is important and what different options there are to define where to look for tailwind classes.
 
@@ -30,6 +30,7 @@ If an utility is not supported or you have built your own, you can change the ma
 import {
   getDefaultCallees,
   getDefaultClassAttributes,
+  getDefaultTags,
   getDefaultVariables
 } from "eslint-plugin-readable-tailwind/api/defaults";
 ```
@@ -67,6 +68,18 @@ export default [
           ]
         ]
       }],
+      "readable-tailwind/no-duplicate-classes": ["warn", {
+        classAttributes: [
+          ...getDefaultClassAttributes(),
+          [
+            "myAttribute", [
+              {
+                match: MatcherType.String
+              }
+            ]
+          ]
+        ]
+      }],
       "readable-tailwind/no-unnecessary-whitespace": ["warn", {
         variables: [
           ...getDefaultVariables(),
@@ -81,9 +94,9 @@ export default [
       }],
       "readable-tailwind/sort-classes": ["warn", {
         classAttributes: [
-          ...getDefaultClassAttributes(),
+          ...getDefaultTags(),
           [
-            "myAttribute", [
+            "tw", [
               {
                 match: MatcherType.String
               }

--- a/docs/api/defaults.md
+++ b/docs/api/defaults.md
@@ -96,7 +96,7 @@ export default [
         classAttributes: [
           ...getDefaultTags(),
           [
-            "tw", [
+            "myTag", [
               {
                 match: MatcherType.String
               }

--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -72,7 +72,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `callees`
 
-  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of function names which arguments should get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -81,10 +81,21 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `variables`
 
-  List of variable names which initializer should also get linted.  This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of variable names whose initializer should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+<br/>
+
+- `tags`
+
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
 
 <br/>
 

--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -63,7 +63,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md).
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md).  
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -72,7 +72,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `callees`
 
-  List of function names which arguments should get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of function names which arguments should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -81,7 +81,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `variables`
 
-  List of variable names whose initializer should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).
+  List of variable names whose initializer should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
@@ -90,7 +90,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 - `tags`
 
-  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: None

--- a/docs/rules/no-duplicate-classes.md
+++ b/docs/rules/no-duplicate-classes.md
@@ -8,7 +8,7 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md).  
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -17,7 +17,7 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `callees`
 
-  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -26,10 +26,21 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+<br/>
+
+- `tags`
+
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
 
 <br/>
 

--- a/docs/rules/no-duplicate-classes.md
+++ b/docs/rules/no-duplicate-classes.md
@@ -26,7 +26,7 @@ Disallow duplicate classes in tailwindcss class strings.
 
 - `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
+  List of variable names whose initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`

--- a/docs/rules/no-unnecessary-whitespace.md
+++ b/docs/rules/no-unnecessary-whitespace.md
@@ -36,7 +36,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 
 - `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
+  List of variable names whose initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`

--- a/docs/rules/no-unnecessary-whitespace.md
+++ b/docs/rules/no-unnecessary-whitespace.md
@@ -9,7 +9,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 - `allowMultiline`
 
   Allow multi-line class declarations.  
-  If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [readable-tailwind/multiline](./multiline.md).
+  If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [readable-tailwind/multiline](./multiline.md).  
   
   **Type**: `boolean`  
   **Default**: `true`
@@ -18,7 +18,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md).  
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -27,7 +27,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 
 - `callees`
 
-  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -36,10 +36,21 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 
 - `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+<br/>
+
+- `tags`
+
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
 
 <br/>
 

--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -33,7 +33,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `classAttributes`
 
-  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md).  
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -42,7 +42,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `callees`
 
-  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -51,10 +51,21 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+<br/>
+
+- `tags`
+
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
 
 <br/>
 

--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -51,7 +51,7 @@ Enforce the order of tailwind classes. It is possible to sort classes alphabetic
 
 - `variables`
 
-  List of variable names which initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
+  List of variable names whose initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md).  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -9,7 +9,7 @@
 <br />
 <br />
 
-The settings object can be used to globally configure shared options across all rules. Global will always be overridden by rule-specific options.
+The settings object can be used to globally configure shared options across all rules. Global options will always be overridden by rule-specific options.
 To set the settings object, add a `settings` key to the eslint config.
 
 <br />
@@ -34,7 +34,7 @@ To set the settings object, add a `settings` key to the eslint config.
 
 ### `classAttributes`
 
-  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md.
+  The name of the attribute that contains the tailwind classes.  
 
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
@@ -43,7 +43,7 @@ To set the settings object, add a `settings` key to the eslint config.
 
 ### `callees`
 
-  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of function names which arguments should also get linted.  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
@@ -52,7 +52,18 @@ To set the settings object, add a `settings` key to the eslint config.
 
 ### `variables`
 
-  List of variable names which initializer should also get linted.  This can also be set globally via the [`settings` object](../settings/settings.md.
+  List of variable names whose initializer should also get linted.  
   
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+- `tags`
+
+  List of template literal tag names whose content should get linted.  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
+
+<br/>

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -57,6 +57,8 @@ To set the settings object, add a `settings` key to the eslint config.
   **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
   **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
 
+<br/>
+
 - `tags`
 
   List of template literal tag names whose content should get linted.  
@@ -65,5 +67,3 @@ To set the settings object, add a `settings` key to the eslint config.
   **Default**: None
 
   Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
-
-<br/>

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -21,9 +21,10 @@ To set the settings object, add a `settings` key to the eslint config.
   "rules": { /* ... */ },
   "settings": {
     "readable-tailwind": {
-      "classAttributes": ["class", "className"],
-      "callees": ["cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"],
-      "variables": ["className", "classNames", "classes", "style", "styles"]
+      "classAttributes": [/* ... */],
+      "callees": [/* ... */],
+      "variables": [/* ... */],
+      "tags": [/* ... */]
     }
   }
 }

--- a/src/api/defaults.ts
+++ b/src/api/defaults.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_ATTRIBUTE_NAMES,
   DEFAULT_CALLEE_NAMES,
+  DEFAULT_TAG_NAMES,
   DEFAULT_VARIABLE_NAMES
 } from "readable-tailwind:options:default-options.js";
 
@@ -15,4 +16,8 @@ export function getDefaultClassAttributes() {
 
 export function getDefaultVariables() {
   return DEFAULT_VARIABLE_NAMES;
+}
+
+export function getDefaultTags() {
+  return DEFAULT_TAG_NAMES;
 }

--- a/src/options/default-options.ts
+++ b/src/options/default-options.ts
@@ -13,7 +13,7 @@ import { TW_JOIN } from "readable-tailwind:options:callees/twJoin.js";
 import { TW_MERGE } from "readable-tailwind:options:callees/twMerge.js";
 import { MatcherType } from "readable-tailwind:types:rule.js";
 
-import type { Callees, ClassAttributes, Variables } from "readable-tailwind:types:rule.js";
+import type { Callees, ClassAttributes, Tags, Variables } from "readable-tailwind:types:rule.js";
 
 
 export const DEFAULT_CALLEE_NAMES = [
@@ -97,3 +97,5 @@ export const DEFAULT_VARIABLE_NAMES = [
     ]
   ]
 ] satisfies Variables;
+
+export const DEFAULT_TAG_NAMES = [] satisfies Tags;

--- a/src/options/descriptions.ts
+++ b/src/options/descriptions.ts
@@ -245,7 +245,7 @@ const TAG_REGEX_CONFIG = {
   description: "List of regular expressions that matches string literals which should get linted.",
   items: [
     {
-      description: "Regular expression that filters the variable and matches the content for further processing in a group.",
+      description: "Regular expression that filters the tags and matches the content for further processing in a group.",
       type: "string"
     },
     {
@@ -260,7 +260,7 @@ const TAG_MATCHER_CONFIG = {
   description: "List of matchers that will automatically be matched.",
   items: [
     {
-      description: "Variable name for which children get linted if matched.",
+      description: "Tag name for which children get linted if matched.",
       type: "string"
     },
     {

--- a/src/options/descriptions.ts
+++ b/src/options/descriptions.ts
@@ -7,7 +7,7 @@ export function getClassAttributeSchema(defaultValue: unknown) {
   return {
     classAttributes: {
       default: defaultValue,
-      description: "List of attribute names that should also get linted.",
+      description: "List of attribute names that should get linted.",
       items: {
         anyOf: [
           CLASS_ATTRIBUTE_NAME_CONFIG,
@@ -24,12 +24,12 @@ export function getCalleeSchema(defaultValue: unknown) {
   return {
     callees: {
       default: defaultValue,
-      description: "List of function names which arguments should also get linted.",
+      description: "List of function names which arguments should get linted.",
       items: {
         anyOf: [
           CALLEE_REGEX_CONFIG,
           CALLEE_MATCHER_CONFIG,
-          CALLEE_ATTRIBUTE_NAME_CONFIG
+          CALLEE_NAME_CONFIG
         ]
       },
       type: "array"
@@ -41,12 +41,29 @@ export function getVariableSchema(defaultValue: unknown) {
   return {
     variables: {
       default: defaultValue,
-      description: "List of variable names which values should also get linted.",
+      description: "List of variable names which values should get linted.",
       items: {
         anyOf: [
           VARIABLE_REGEX_CONFIG,
           VARIABLE_MATCHER_CONFIG,
-          VARIABLE_ATTRIBUTE_NAME_CONFIG
+          VARIABLE_NAME_CONFIG
+        ]
+      },
+      type: "array"
+    }
+  } satisfies Rule.RuleMetaData["schema"];
+}
+
+export function getTagsSchema(defaultValue: unknown) {
+  return {
+    tags: {
+      default: defaultValue,
+      description: "List of template literal tags that should get linted.",
+      items: {
+        anyOf: [
+          TAG_REGEX_CONFIG,
+          TAG_MATCHER_CONFIG,
+          TAG_NAME_CONFIG
         ]
       },
       type: "array"
@@ -96,7 +113,7 @@ const OBJECT_VALUE_MATCHER_SCHEMA = {
 } satisfies Rule.RuleMetaData["schema"];
 
 const CLASS_ATTRIBUTE_REGEX_CONFIG = {
-  description: "List of regular expressions that matches string literals that should also get linted.",
+  description: "List of regular expressions that matches string literals which should get linted.",
   items: [
     {
       description: "Regular expression that filters the attribute and matches the content for further processing in a group.",
@@ -114,7 +131,7 @@ const CLASS_ATTRIBUTE_MATCHER_CONFIG = {
   description: "List of matchers that will automatically be matched.",
   items: [
     {
-      description: "Attribute name which children get linted if matched.",
+      description: "Attribute name for which children get linted if matched.",
       type: "string"
     },
     {
@@ -134,12 +151,12 @@ const CLASS_ATTRIBUTE_MATCHER_CONFIG = {
 };
 
 const CLASS_ATTRIBUTE_NAME_CONFIG = {
-  description: "Attribute name that which children get linted.",
+  description: "Attribute name that for which children get linted.",
   type: "string"
 };
 
 const CALLEE_REGEX_CONFIG = {
-  description: "List of regular expressions that matches string literals that should also get linted.",
+  description: "List of regular expressions that matches string literals which should get linted.",
   items: [
     {
       description: "Regular expression that filters the callee and matches the content for further processing in a group.",
@@ -157,7 +174,7 @@ const CALLEE_MATCHER_CONFIG = {
   description: "List of matchers that will automatically be matched.",
   items: [
     {
-      description: "Callee name which children get linted if matched.",
+      description: "Callee name for which children get linted if matched.",
       type: "string"
     },
     {
@@ -176,13 +193,13 @@ const CALLEE_MATCHER_CONFIG = {
   type: "array"
 };
 
-const CALLEE_ATTRIBUTE_NAME_CONFIG = {
-  description: "Callee name which children get linted.",
+const CALLEE_NAME_CONFIG = {
+  description: "Callee name for which children get linted.",
   type: "string"
 };
 
 const VARIABLE_REGEX_CONFIG = {
-  description: "List of regular expressions that matches string literals that should also get linted.",
+  description: "List of regular expressions that matches string literals which should get linted.",
   items: [
     {
       description: "Regular expression that filters the variable and matches the content for further processing in a group.",
@@ -200,7 +217,7 @@ const VARIABLE_MATCHER_CONFIG = {
   description: "List of matchers that will automatically be matched.",
   items: [
     {
-      description: "Variable name which children get linted if matched.",
+      description: "Variable name for which children get linted if matched.",
       type: "string"
     },
     {
@@ -219,7 +236,50 @@ const VARIABLE_MATCHER_CONFIG = {
   type: "array"
 };
 
-const VARIABLE_ATTRIBUTE_NAME_CONFIG = {
-  description: "Variable name which children get linted.",
+const VARIABLE_NAME_CONFIG = {
+  description: "Variable name for which children get linted.",
+  type: "string"
+};
+
+const TAG_REGEX_CONFIG = {
+  description: "List of regular expressions that matches string literals which should get linted.",
+  items: [
+    {
+      description: "Regular expression that filters the variable and matches the content for further processing in a group.",
+      type: "string"
+    },
+    {
+      description: "Regular expression that matches each string literal in a group.",
+      type: "string"
+    }
+  ],
+  type: "array"
+};
+
+const TAG_MATCHER_CONFIG = {
+  description: "List of matchers that will automatically be matched.",
+  items: [
+    {
+      description: "Variable name for which children get linted if matched.",
+      type: "string"
+    },
+    {
+      description: "List of matchers that will be applied.",
+      items: {
+        anyOf: [
+          STRING_MATCHER_SCHEMA,
+          OBJECT_KEY_MATCHER_SCHEMA,
+          OBJECT_VALUE_MATCHER_SCHEMA
+        ],
+        type: "object"
+      },
+      type: "array"
+    }
+  ],
+  type: "array"
+};
+
+const TAG_NAME_CONFIG = {
+  description: "Template literal tag name that should get linted.",
   type: "string"
 };

--- a/src/options/descriptions.ts
+++ b/src/options/descriptions.ts
@@ -245,7 +245,7 @@ const TAG_REGEX_CONFIG = {
   description: "List of regular expressions that matches string literals which should get linted.",
   items: [
     {
-      description: "Regular expression that filters the tags and matches the content for further processing in a group.",
+      description: "Regular expression that filters the template literal tags and matches the content for further processing in a group.",
       type: "string"
     },
     {
@@ -260,7 +260,7 @@ const TAG_MATCHER_CONFIG = {
   description: "List of matchers that will automatically be matched.",
   items: [
     {
-      description: "Tag name for which children get linted if matched.",
+      description: "Template literal tag for which children get linted if matched.",
       type: "string"
     },
     {
@@ -280,6 +280,6 @@ const TAG_MATCHER_CONFIG = {
 };
 
 const TAG_NAME_CONFIG = {
-  description: "Template literal tag name that should get linted.",
+  description: "Template literal tag that should get linted.",
   type: "string"
 };

--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -27,10 +27,10 @@ import type {
   Node as ESNode,
   SimpleLiteral as ESSimpleLiteral,
   SpreadElement as ESSpreadElement,
+  TaggedTemplateExpression as ESTaggedTemplateExpression,
   TemplateElement as ESTemplateElement,
   TemplateLiteral as ESTemplateLiteral,
-  VariableDeclarator as ESVariableDeclarator,
-  TaggedTemplateExpression
+  VariableDeclarator as ESVariableDeclarator
 } from "estree";
 
 import type { BracesMeta, Literal, Node, StringLiteral, TemplateLiteral } from "readable-tailwind:types:ast.js";
@@ -83,7 +83,7 @@ export function getLiteralsByESCallExpression(ctx: Rule.RuleContext, node: ESCal
 
 }
 
-export function getLiteralsByTaggedTemplateExpression(ctx: Rule.RuleContext, node: TaggedTemplateExpression, tags: Tags): Literal[] {
+export function getLiteralsByTaggedTemplateExpression(ctx: Rule.RuleContext, node: ESTaggedTemplateExpression, tags: Tags): Literal[] {
 
   const literals = tags.reduce<Literal[]>((literals, tag) => {
     if(!isTaggedTemplateSymbol(node.tag)){ return literals; }
@@ -308,7 +308,7 @@ function isESCalleeSymbol(node: ESBaseNode & Partial<Rule.NodeParentExtension>):
   return node.type === "Identifier" && !!node.parent && isESCallExpression(node.parent);
 }
 
-function isTaggedTemplateExpression(node: ESBaseNode): node is TaggedTemplateExpression {
+function isTaggedTemplateExpression(node: ESBaseNode): node is ESTaggedTemplateExpression {
   return node.type === "TaggedTemplateExpression";
 }
 

--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -7,6 +7,9 @@ import {
   isCalleeRegex,
   isInsideConditionalExpressionTest,
   isInsideLogicalExpressionLeft,
+  isTagMatchers,
+  isTagName,
+  isTagRegex,
   isVariableMatchers,
   isVariableName,
   isVariableRegex,
@@ -26,11 +29,12 @@ import type {
   SpreadElement as ESSpreadElement,
   TemplateElement as ESTemplateElement,
   TemplateLiteral as ESTemplateLiteral,
-  VariableDeclarator as ESVariableDeclarator
+  VariableDeclarator as ESVariableDeclarator,
+  TaggedTemplateExpression
 } from "estree";
 
 import type { BracesMeta, Literal, Node, StringLiteral, TemplateLiteral } from "readable-tailwind:types:ast.js";
-import type { Callees, Matcher, MatcherFunctions, Variables } from "readable-tailwind:types:rule.js";
+import type { Callees, Matcher, MatcherFunctions, Tags, Variables } from "readable-tailwind:types:rule.js";
 
 
 export function getLiteralsByESVariableDeclarator(ctx: Rule.RuleContext, node: ESVariableDeclarator, variables: Variables): Literal[] {
@@ -70,6 +74,28 @@ export function getLiteralsByESCallExpression(ctx: Rule.RuleContext, node: ESCal
     } else if(isCalleeMatchers(callee)){
       if(callee[0] !== node.callee.name){ return literals; }
       literals.push(...getLiteralsByESMatchers(ctx, node, callee[1]));
+    }
+
+    return literals;
+  }, []);
+
+  return deduplicateLiterals(literals);
+
+}
+
+export function getLiteralsByTaggedTemplateExpression(ctx: Rule.RuleContext, node: TaggedTemplateExpression, tags: Tags): Literal[] {
+
+  const literals = tags.reduce<Literal[]>((literals, tag) => {
+    if(!isTaggedTemplateSymbol(node.tag)){ return literals; }
+
+    if(isTagName(tag)){
+      if(tag !== node.tag.name){ return literals; }
+      literals.push(...getLiteralsByESTemplateLiteral(ctx, node.quasi));
+    } else if(isTagRegex(tag)){
+      literals.push(...getLiteralsByESNodeAndRegex(ctx, node, tag));
+    } else if(isTagMatchers(tag)){
+      if(tag[0] !== node.tag.name){ return literals; }
+      literals.push(...getLiteralsByESMatchers(ctx, node, tag[1]));
     }
 
     return literals;
@@ -280,6 +306,14 @@ export function isESCallExpression(node: ESBaseNode): node is ESCallExpression {
 
 function isESCalleeSymbol(node: ESBaseNode & Partial<Rule.NodeParentExtension>): node is ESIdentifier {
   return node.type === "Identifier" && !!node.parent && isESCallExpression(node.parent);
+}
+
+function isTaggedTemplateExpression(node: ESBaseNode): node is TaggedTemplateExpression {
+  return node.type === "TaggedTemplateExpression";
+}
+
+function isTaggedTemplateSymbol(node: ESBaseNode & Partial<Rule.NodeParentExtension>): node is ESIdentifier {
+  return node.type === "Identifier" && !!node.parent && isTaggedTemplateExpression(node.parent);
 }
 
 export function isESVariableDeclarator(node: ESBaseNode): node is ESVariableDeclarator {

--- a/src/rules/tailwind-multiline.test.ts
+++ b/src/rules/tailwind-multiline.test.ts
@@ -1186,4 +1186,42 @@ describe(tailwindMultiline.name, () => {
 
   });
 
+  it("should remove duplicate classes in string literals in defined tagged template literals", () => {
+    lint(
+      tailwindMultiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            jsx: "defined` a b c d e f g h `",
+            jsxOutput: "defined`\n  a b c\n  d e f\n  g h\n`",
+            options: [{
+              classesPerLine: 3,
+              indent: 2,
+              tags: ["defined"]
+            }],
+            svelte: "<script>defined` a b c d e f g h `</script>",
+            svelteOutput: "<script>defined`\n  a b c\n  d e f\n  g h\n`</script>",
+            vue: "<script>defined` a b c d e f g h `</script>",
+            vueOutput: "<script>defined`\n  a b c\n  d e f\n  g h\n`</script>"
+          }
+        ],
+        valid: [
+          {
+            jsx: "notDefined` a b c d e f g h `",
+            options: [{
+              classesPerLine: 3,
+              indent: 2,
+              tags: ["defined"]
+            }],
+            svelte: "<script>notDefined` a b c d e f g h `</script>",
+            vue: "notDefined` a b c d e f g h `"
+          }
+        ]
+      }
+    );
+
+  });
+
 });

--- a/src/rules/tailwind-no-duplicate-classes.test.ts
+++ b/src/rules/tailwind-no-duplicate-classes.test.ts
@@ -574,4 +574,33 @@ describe(tailwindNoDuplicateClasses.name, () => {
 
   });
 
+  it("should remove duplicate classes in string literals in defined tagged template literals", () => {
+    lint(
+      tailwindNoDuplicateClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            jsx: "defined` a b a `",
+            jsxOutput: "defined` a b  `",
+            options: [{ tags: ["defined"] }],
+            svelte: "<script>defined` a b a `</script>",
+            svelteOutput: "<script>defined` a b  `</script>",
+            vue: "defined` a b a `",
+            vueOutput: "defined` a b  `"
+          }
+        ],
+        valid: [
+          {
+            jsx: "notDefined` a b a `",
+            options: [{ tags: ["defined"] }],
+            svelte: "<script>notDefined` a b a `</script>",
+            vue: "notDefined` a b a `"
+          }
+        ]
+      }
+    );
+  });
+
 });

--- a/src/rules/tailwind-no-unnecessary-whitespace.test.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.test.ts
@@ -836,4 +836,33 @@ describe(tailwindNoUnnecessaryWhitespace.name, () => {
 
   });
 
+  it("should remove unnecessary whitespace in string literals in defined tagged template literals", () => {
+    lint(
+      tailwindNoUnnecessaryWhitespace,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            jsx: "defined`  b   a  `",
+            jsxOutput: "defined`b a`",
+            options: [{ tags: ["defined"] }],
+            svelte: "<script>defined`  b   a  `</script>",
+            svelteOutput: "<script>defined`b a`</script>",
+            vue: "defined`  b   a  `",
+            vueOutput: "defined`b a`"
+          }
+        ],
+        valid: [
+          {
+            jsx: "notDefined`  b   a  `",
+            options: [{ tags: ["defined"] }],
+            svelte: "<script>notDefined`  b   a  `</script>",
+            vue: "notDefined`  b   a  `"
+          }
+        ]
+      }
+    );
+  });
+
 });

--- a/src/rules/tailwind-sort-classes.test.ts
+++ b/src/rules/tailwind-sort-classes.test.ts
@@ -625,4 +625,33 @@ describe(tailwindSortClasses.name, () => {
 
   });
 
+  it("should sort simple class names in tagged template literals", () => {
+    lint(
+      tailwindSortClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            errors: 1,
+            jsx: "defined`b a`",
+            jsxOutput: "defined`a b`",
+            options: [{ order: "asc", tags: ["defined"] }],
+            svelte: "<script>defined`b a`</script>",
+            svelteOutput: "<script>defined`a b`</script>",
+            vue: "defined`b a`",
+            vueOutput: "defined`a b`"
+          }
+        ],
+        valid: [
+          {
+            jsx: "defined`a b`",
+            options: [{ order: "asc", tags: ["defined"] }],
+            svelte: "<script>defined`a b`</script>",
+            vue: "defined`a b`"
+          }
+        ]
+      }
+    );
+  });
+
 });

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -48,6 +48,14 @@ export type VariableOption = {
   variables: Variables;
 };
 
+export type TagName = string;
+export type TagMatchers = [tag: TagName, matchers: Matcher[]];
+export type TagRegex = [tagRegex: Regex, literalRegex: Regex];
+export type Tags = (TagMatchers | TagName | TagRegex)[];
+export type TagOption = {
+  tags: Tags;
+};
+
 export type ClassAttributeName = string;
 export type ClassAttributeMatchers = [classAttribute: ClassAttributeName, matchers: Matcher[]];
 export type ClassAttributeRegex = [classAttributeRegex: Regex, literalRegex: Regex];

--- a/src/utils/matchers.test.ts
+++ b/src/utils/matchers.test.ts
@@ -351,6 +351,87 @@ describe("matchers", () => {
 
   });
 
+  describe("template literal tags", () => {
+
+    it("should lint class names in tagged template literals when matched using the strings matcher", () => {
+      lint(
+        tailwindNoUnnecessaryWhitespace,
+        TEST_SYNTAXES,
+        {
+          invalid: [
+            {
+              errors: 1,
+              jsx: "defined`  lint  lint  `",
+              jsxOutput: "defined`lint lint`",
+              options: [{ tags: [["defined", [{ match: MatcherType.String }]]] }],
+              svelte: "<script>defined`  lint  lint  `</script>",
+              svelteOutput: "<script>defined`lint lint`</script>",
+              vue: "defined`  lint  lint  `",
+              vueOutput: "defined`lint lint`"
+            }
+          ]
+        }
+      );
+    });
+
+    it("should lint class names in nested literal expressions inside tagged template literals when matched using the strings matcher", () => {
+      // eslint thinks the fixes are conflicting so it only applies the first iteration
+      lint(
+        tailwindNoUnnecessaryWhitespace,
+        TEST_SYNTAXES,
+        {
+          invalid: [
+            {
+              errors: 3,
+              jsx: "defined` lint ${\"  lint  lint  \"} lint `",
+              jsxOutput: "defined`lint ${\"  lint  lint  \"} lint`",
+              options: [{ tags: [["defined", [{ match: MatcherType.String }]]] }],
+              svelte: "<script>defined` lint ${\"  lint  lint  \"} lint `</script>",
+              svelteOutput: "<script>defined`lint ${\"  lint  lint  \"} lint`</script>",
+              vue: "defined` lint ${\"  lint  lint  \"} lint `",
+              vueOutput: "defined`lint ${\"  lint  lint  \"} lint`"
+            }
+          ],
+          valid: [
+            {
+              jsx: "notDefined` lint ${\"  lint  lint  \"} lint `",
+              options: [{ tags: [["defined", [{ match: MatcherType.String }]]] }],
+              svelte: "<script>notDefined` lint ${\"  lint  lint  \"} lint `</script>",
+              vue: "notDefined` lint ${\"  lint  lint  \"} lint `"
+            }
+          ]
+        }
+      );
+      lint(
+        tailwindNoUnnecessaryWhitespace,
+        TEST_SYNTAXES,
+        {
+          invalid: [
+            {
+              errors: 1,
+              jsx: "defined`lint ${\"  lint  lint  \"} lint`",
+              jsxOutput: "defined`lint ${\"lint lint\"} lint`",
+              options: [{ tags: [["defined", [{ match: MatcherType.String }]]] }],
+              svelte: "<script>defined`lint ${\"  lint  lint  \"} lint`</script>",
+              svelteOutput: "<script>defined`lint ${\"lint lint\"} lint`</script>",
+              vue: "defined`lint ${\"  lint  lint  \"} lint`",
+              vueOutput: "defined`lint ${\"lint lint\"} lint`"
+            }
+          ],
+          valid: [
+            {
+              jsx: "notDefined`lint ${\"  lint  lint  \"} lint`",
+              options: [{ tags: [["defined", [{ match: MatcherType.String }]]] }],
+              svelte: "<script>notDefined`lint ${\"  lint  lint  \"} lint`</script>",
+              vue: "notDefined`lint ${\"  lint  lint  \"} lint`"
+            }
+          ]
+        }
+      );
+    });
+
+  });
+
   it("should lint literals inside object keys when matched", () => {
     lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [
@@ -408,7 +489,7 @@ describe("matchers", () => {
     });
   });
 
-  it("should lint strings inside template literal expressions", () => {
+  it("should lint strings inside template literal expressions when matched using the strings matcher", () => {
     // eslint thinks the fixes are conflicting so it only applies the first iteration
     lint(tailwindNoUnnecessaryWhitespace, TEST_SYNTAXES, {
       invalid: [

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -21,6 +21,10 @@ import type {
   ClassAttributes,
   MatcherFunctions,
   Regex,
+  TagMatchers,
+  TagName,
+  TagRegex,
+  Tags,
   VariableMatchers,
   VariableName,
   VariableRegex,
@@ -177,6 +181,18 @@ export function isVariableRegex(variable: Variables[number]): variable is Variab
 
 export function isVariableMatchers(variable: Variables[number]): variable is VariableMatchers {
   return Array.isArray(variable) && typeof variable[0] === "string" && Array.isArray(variable[1]);
+}
+
+export function isTagName(tag: Tags[number]): tag is TagName {
+  return typeof tag === "string";
+}
+
+export function isTagRegex(tag: Tags[number]): tag is TagRegex {
+  return Array.isArray(tag) && typeof tag[0] === "string" && typeof tag[1] === "string";
+}
+
+export function isTagMatchers(tag: Tags[number]): tag is TagMatchers {
+  return Array.isArray(tag) && typeof tag[0] === "string" && Array.isArray(tag[1]);
 }
 
 export function isClassAttributeName(classAttribute: ClassAttributes[number]): classAttribute is ClassAttributeName {

--- a/src/utils/regex.test.ts
+++ b/src/utils/regex.test.ts
@@ -214,4 +214,52 @@ describe("regex", () => {
 
   });
 
+  describe("template literal tags", () => {
+
+    it("should lint literals in tagged template literals", () => {
+      lint(
+        tailwindNoUnnecessaryWhitespace,
+        TEST_SYNTAXES,
+        {
+          invalid: [
+            {
+              errors: 1,
+              jsx: "defined`  a  b  `",
+              jsxOutput: "defined`a b`",
+              options: [{
+                tags: [
+                  [
+                    "defined`([\\S\\s]*)`",
+                    `(.*)`
+                  ]
+                ]
+              }],
+              svelte: `<script>defined\`  a  b  \`</script>`,
+              svelteOutput: `<script>defined\`a b\`</script>`,
+              vue: `defined\`  a  b  \``,
+              vueOutput: `defined\`a b\``
+            }
+          ],
+          valid: [
+            {
+              jsx: "notDefined`  a  b  `",
+              options: [{
+                tags: [
+                  [
+                    "defined`([\\S\\s]*)`",
+                    `(.*)`
+                  ]
+                ]
+              }],
+              svelte: `<script>notDefined\`  a  b  \`</script>`,
+              vue: `notDefined\`  a  b  \``
+            }
+          ]
+        }
+      );
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
Adds support for tagged template literals. Closes #64 

```tsx
const styles = tw`this will get linted`;
```

This PR does not change the default settings, so no tags will get linted out of the box.

To lint tagged template literals, the best way is to use the [strings matcher](https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/concepts/concepts.md#types-of-matchers) to ensure that nested expressions will get linted correctly.

```ts
{
  //...
  options: [{ 
    tags: [
      [
        "tw", [{ match: MatcherType.String }]
      ]
    ]
  }]
}
```

```tsx
const styles = tw`
  this string will get linted
  ${
    someVar === "this string will NOT get linted" 
      ? "this string will get linted"
      : "this string will get linted"
  }
  this string will get linted
`;
```