### PR TITLE
fix: override settings

### DIFF
--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -62,6 +62,19 @@ export type Options = [
   >
 ];
 
+const defaultOptions = {
+  callees: DEFAULT_CALLEE_NAMES,
+  classAttributes: DEFAULT_ATTRIBUTE_NAMES,
+  classesPerLine: 0,
+  group: "emptyLine",
+  indent: 2,
+  lineBreakStyle: "unix",
+  preferSingleLine: false,
+  printWidth: 80,
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
 export const tailwindMultiline: ESLintRule<Options> = {
   name: "multiline" as const,
   rule: {
@@ -194,23 +207,23 @@ export const tailwindMultiline: ESLintRule<Options> = {
         {
           additionalProperties: false,
           properties: {
-            ...getCalleeSchema(getOptions().callees),
-            ...getClassAttributeSchema(getOptions().classAttributes),
-            ...getVariableSchema(getOptions().variables),
-            ...getTagsSchema(getOptions().tags),
+            ...getCalleeSchema(defaultOptions.callees),
+            ...getClassAttributeSchema(defaultOptions.classAttributes),
+            ...getVariableSchema(defaultOptions.variables),
+            ...getTagsSchema(defaultOptions.tags),
             classesPerLine: {
-              default: getOptions().classesPerLine,
+              default: defaultOptions.classesPerLine,
               description: "The maximum amount of classes per line. Lines are wrapped appropriately to stay within this limit . The value `0` disables line wrapping by `classesPerLine`.",
               type: "integer"
             },
             group: {
-              default: getOptions().group,
+              default: defaultOptions.group,
               description: "Defines how different groups of classes should be separated. A group is a set of classes that share the same modifier/variant.",
               enum: ["emptyLine", "never", "newLine"],
               type: "string"
             },
             indent: {
-              default: getOptions().indent,
+              default: defaultOptions.indent,
               description: "Determines how the code should be indented.",
               oneOf: [
                 {
@@ -224,18 +237,18 @@ export const tailwindMultiline: ESLintRule<Options> = {
               ]
             },
             lineBreakStyle: {
-              default: getOptions().lineBreakStyle,
+              default: defaultOptions.lineBreakStyle,
               description: "The line break style. The style `windows` will use `\\r\\n` as line breaks and `unix` will use `\\n`.",
               enum: ["unix", "windows"],
               type: "string"
             },
             preferSingleLine: {
-              default: getOptions().preferSingleLine,
+              default: defaultOptions.preferSingleLine,
               description: "Prefer a single line for the classes. When set to `true`, the rule will keep all classes on a single line until the line exceeds the `printWidth` or `classesPerLine` limit.",
               type: "boolean"
             },
             printWidth: {
-              default: getOptions().printWidth,
+              default: defaultOptions.printWidth,
               description: "The maximum line length. Lines are wrapped appropriately to stay within this limit. The value `0` disables line wrapping by `printWidth`.",
               type: "integer"
             }
@@ -639,33 +652,33 @@ function getOptions(ctx?: Rule.RuleContext) {
 
   const options: Options[0] = ctx?.options[0] ?? {};
 
-  const printWidth = options.printWidth ?? 80;
-  const classesPerLine = options.classesPerLine ?? 0;
-  const indent = options.indent ?? 2;
-  const group = options.group ?? "emptyLine";
-  const preferSingleLine = options.preferSingleLine ?? false;
+  const printWidth = options.printWidth ?? defaultOptions.printWidth;
+  const classesPerLine = options.classesPerLine ?? defaultOptions.classesPerLine;
+  const indent = options.indent ?? defaultOptions.indent;
+  const group = options.group ?? defaultOptions.group;
+  const preferSingleLine = options.preferSingleLine ?? defaultOptions.preferSingleLine;
 
   const classAttributes = options.classAttributes ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
     ctx?.settings["readable-tailwind"]?.classAttributes ??
-    DEFAULT_ATTRIBUTE_NAMES;
+    defaultOptions.classAttributes;
 
   const callees = options.callees ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
     ctx?.settings["readable-tailwind"]?.callees ??
-    DEFAULT_CALLEE_NAMES;
+    defaultOptions.callees;
 
   const variables = options.variables ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
     ctx?.settings["readable-tailwind"]?.variables ??
-    DEFAULT_VARIABLE_NAMES;
+    defaultOptions.variables;
 
   const tags = options.tags ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.tags ??
     ctx?.settings["readable-tailwind"]?.tags ??
-    DEFAULT_TAG_NAMES;
+    defaultOptions.tags;
 
-  const lineBreakStyle = options.lineBreakStyle ?? "unix";
+  const lineBreakStyle = options.lineBreakStyle ?? defaultOptions.lineBreakStyle;
 
   return {
     callees,

--- a/src/rules/tailwind-no-duplicate-classes.ts
+++ b/src/rules/tailwind-no-duplicate-classes.ts
@@ -54,6 +54,13 @@ export type Options = [
   >
 ];
 
+const defaultOptions = {
+  callees: DEFAULT_CALLEE_NAMES,
+  classAttributes: DEFAULT_ATTRIBUTE_NAMES,
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
 export const tailwindNoDuplicateClasses: ESLintRule<Options> = {
   name: "no-duplicate-classes" as const,
   rule: {
@@ -174,10 +181,10 @@ export const tailwindNoDuplicateClasses: ESLintRule<Options> = {
         {
           additionalProperties: false,
           properties: {
-            ...getCalleeSchema(getOptions().callees),
-            ...getClassAttributeSchema(getOptions().classAttributes),
-            ...getVariableSchema(getOptions().variables),
-            ...getTagsSchema(getOptions().tags)
+            ...getCalleeSchema(defaultOptions.callees),
+            ...getClassAttributeSchema(defaultOptions.classAttributes),
+            ...getVariableSchema(defaultOptions.variables),
+            ...getTagsSchema(defaultOptions.tags)
           },
           type: "object"
         }
@@ -347,22 +354,22 @@ function getOptions(ctx?: Rule.RuleContext) {
   const classAttributes = options.classAttributes ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
     ctx?.settings["readable-tailwind"]?.classAttributes ??
-    DEFAULT_ATTRIBUTE_NAMES;
+    defaultOptions.classAttributes;
 
   const callees = options.callees ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
     ctx?.settings["readable-tailwind"]?.callees ??
-    DEFAULT_CALLEE_NAMES;
+    defaultOptions.callees;
 
   const variables = options.variables ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
     ctx?.settings["readable-tailwind"]?.variables ??
-    DEFAULT_VARIABLE_NAMES;
+    defaultOptions.variables;
 
   const tags = options.tags ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.tags ??
     ctx?.settings["readable-tailwind"]?.tags ??
-    DEFAULT_TAG_NAMES;
+    defaultOptions.tags;
 
   return {
     callees,

--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -51,6 +51,14 @@ export type Options = [
   >
 ];
 
+const defaultOptions = {
+  allowMultiline: true,
+  callees: DEFAULT_CALLEE_NAMES,
+  classAttributes: DEFAULT_ATTRIBUTE_NAMES,
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
 export const tailwindNoUnnecessaryWhitespace: ESLintRule<Options> = {
   name: "no-unnecessary-whitespace" as const,
   rule: {
@@ -172,14 +180,14 @@ export const tailwindNoUnnecessaryWhitespace: ESLintRule<Options> = {
           additionalProperties: false,
           properties: {
             allowMultiline: {
-              default: getOptions().allowMultiline,
+              default: defaultOptions.allowMultiline,
               description: "Allow multi-line class declarations. If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [readable-tailwind/multiline](./multiline.md).",
               type: "boolean"
             },
-            ...getCalleeSchema(getOptions().callees),
-            ...getClassAttributeSchema(getOptions().classAttributes),
-            ...getVariableSchema(getOptions().variables),
-            ...getTagsSchema(getOptions().tags)
+            ...getCalleeSchema(defaultOptions.callees),
+            ...getClassAttributeSchema(defaultOptions.classAttributes),
+            ...getVariableSchema(defaultOptions.variables),
+            ...getTagsSchema(defaultOptions.tags)
           },
           type: "object"
         }
@@ -278,27 +286,27 @@ function getOptions(ctx?: Rule.RuleContext) {
 
   const options: Options[0] = ctx?.options[0] ?? {};
 
-  const allowMultiline = options.allowMultiline ?? true;
+  const allowMultiline = options.allowMultiline ?? defaultOptions.allowMultiline;
 
   const classAttributes = options.classAttributes ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
     ctx?.settings["readable-tailwind"]?.classAttributes ??
-    DEFAULT_ATTRIBUTE_NAMES;
+    defaultOptions.classAttributes;
 
   const callees = options.callees ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
     ctx?.settings["readable-tailwind"]?.callees ??
-    DEFAULT_CALLEE_NAMES;
+    defaultOptions.callees;
 
   const variables = options.variables ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
     ctx?.settings["readable-tailwind"]?.variables ??
-    DEFAULT_VARIABLE_NAMES;
+    defaultOptions.variables;
 
   const tags = options.tags ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.tags ??
     ctx?.settings["readable-tailwind"]?.tags ??
-    DEFAULT_TAG_NAMES;
+    defaultOptions.tags;
 
   return {
     allowMultiline,

--- a/src/rules/tailwind-sort-classes.ts
+++ b/src/rules/tailwind-sort-classes.ts
@@ -60,6 +60,14 @@ export type Options = [
   >
 ];
 
+const defaultOptions = {
+  callees: DEFAULT_CALLEE_NAMES,
+  classAttributes: DEFAULT_ATTRIBUTE_NAMES,
+  order: "improved",
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
 const TAILWIND_CONFIG_CACHE = new Map<string, ReturnType<typeof resolveConfig<Config>>>();
 const TAILWIND_CONTEXT_CACHE = new Map<ReturnType<typeof resolveConfig>, TailwindContext>();
 
@@ -251,12 +259,12 @@ export const tailwindSortClasses: ESLintRule<Options> = {
         {
           additionalProperties: false,
           properties: {
-            ...getCalleeSchema(getOptions().callees),
-            ...getClassAttributeSchema(getOptions().classAttributes),
-            ...getVariableSchema(getOptions().variables),
-            ...getTagsSchema(getOptions().tags),
+            ...getCalleeSchema(defaultOptions.callees),
+            ...getClassAttributeSchema(defaultOptions.classAttributes),
+            ...getVariableSchema(defaultOptions.variables),
+            ...getTagsSchema(defaultOptions.tags),
             order: {
-              default: getOptions().order,
+              default: defaultOptions.order,
               description: "The algorithm to use when sorting classes.",
               enum: [
                 "asc",
@@ -267,7 +275,6 @@ export const tailwindSortClasses: ESLintRule<Options> = {
               type: "string"
             },
             tailwindConfig: {
-              default: getOptions().tailwindConfig,
               description: "The path to the tailwind config file. If not specified, the plugin will try to find it automatically or falls back to the default configuration.",
               type: "string"
             }
@@ -374,27 +381,27 @@ export function getOptions(ctx?: Rule.RuleContext) {
 
   const options: Options[0] = ctx?.options[0] ?? {};
 
-  const order = options.order ?? "improved";
+  const order = options.order ?? defaultOptions.order;
 
   const classAttributes = options.classAttributes ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.classAttributes ??
     ctx?.settings["readable-tailwind"]?.classAttributes ??
-    DEFAULT_ATTRIBUTE_NAMES;
+    defaultOptions.classAttributes;
 
   const callees = options.callees ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.callees ??
     ctx?.settings["readable-tailwind"]?.callees ??
-    DEFAULT_CALLEE_NAMES;
+    defaultOptions.callees;
 
   const variables = options.variables ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.variables ??
     ctx?.settings["readable-tailwind"]?.variables ??
-    DEFAULT_VARIABLE_NAMES;
+    defaultOptions.variables;
 
   const tags = options.tags ??
     ctx?.settings["eslint-plugin-readable-tailwind"]?.tags ??
     ctx?.settings["readable-tailwind"]?.tags ??
-    DEFAULT_TAG_NAMES;
+    defaultOptions.tags;
 
   const tailwindConfig = options.tailwindConfig;
 


### PR DESCRIPTION
Fixes an issue that rule options did not override [settings](https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/settings/settings.md#settings).

```jsonc
{
  // rule options
  rules: {
    "eslint-plugin-readable-tailwind/no-unnecessary-whitespace": ["warn", {
      /* should override settings below */
    }]
  },
  // plugin settings
  settings: {
    "eslint-plugin-readable-tailwind": {
      /* should get overwritten */
    }
  }
}
```