### PR TITLE
fix: lint `className` in render functions inside object

### DIFF
--- a/src/options/default-options.ts
+++ b/src/options/default-options.ts
@@ -34,6 +34,7 @@ export const DEFAULT_CALLEE_NAMES = [
 
 export const DEFAULT_ATTRIBUTE_NAMES = [
   "class",
+  "className",
   [
     "class", [
       {


### PR DESCRIPTION
Adds  `className` to the default  attribute names.
The `className` matcher does not work because the whole JSX expression is inside an object.

https://github.com/schoero/eslint-plugin-readable-tailwind/blob/3843fe28fc9ef4820e9bcb03814a99beaed639e8/src/parsers/es.ts#L353

```tsx
const Example: Story = {
  render: () => (
    <div className="rounded-md h-48 w-48 relative after:h-8 after:w-8 after:absolute after:right-4 after:rotate-45">
      Some content
    </div>
  )
}
```

closes #74

