### PR TITLE
fix: keep original newline characters

### DIFF
--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -86,10 +86,15 @@ function getLiteralsByVueMatchers(ctx: Rule.RuleContext, node: ESBaseNode, match
 
 function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLiteral): StringLiteral {
 
-  const content = node.value;
   const raw = ctx.sourceCode.getText(node as unknown as ESNode);
-
   const quotes = getQuotes(raw);
+
+  // #81: node.value converts \r\n to \n
+  const content = raw.substring(
+    quotes.openingQuote?.length ?? 0,
+    raw.length - (quotes.closingQuote?.length ?? 0)
+  );
+
   const whitespaces = getWhitespace(content);
 
   return {

--- a/src/rules/tailwind-no-duplicate-classes.test.ts
+++ b/src/rules/tailwind-no-duplicate-classes.test.ts
@@ -603,4 +603,65 @@ describe(tailwindNoDuplicateClasses.name, () => {
     );
   });
 
+  // #81
+  it("should not report duplicates for carriage return characters", () => {
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      valid: [
+        {
+          html: `<img class="  b  a \r\n c  \r\n  d  " />`,
+          jsx: `() => <img class="  b  a \r\n c  \r\n  d  " />`,
+          svelte: `<img class="  b  a \r\n c  \r\n  d  " />`,
+          vue: `<template><img class="  b  a \r\n c  \r\n  d  " /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should not report duplicates for newline characters", () => {
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      valid: [
+        {
+          html: `<img class="  b  a \n c  \n  d  " />`,
+          jsx: `() => <img class="  b  a \n c  \n  d  " />`,
+          svelte: `<img class="  b  a \n c  \n  d  " />`,
+          vue: `<template><img class="  b  a \n c  \n  d  " /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report fixes with unchanged line endings", () => {
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<img class="  b  a \r\n c  \r\n a d  " />`,
+          htmlOutput: `<img class="  b  a \r\n c  \r\n  d  " />`,
+          jsx: `() => <img class="  b  a \r\n c  \r\n a d  " />`,
+          jsxOutput: `() => <img class="  b  a \r\n c  \r\n  d  " />`,
+          svelte: `<img class="  b  a \r\n c  \r\n a d  " />`,
+          svelteOutput: `<img class="  b  a \r\n c  \r\n  d  " />`,
+          vue: `<template><img class="  b  a \r\n c  \r\n a d  " /></template>`,
+          vueOutput: `<template><img class="  b  a \r\n c  \r\n  d  " /></template>`
+        }
+      ]
+    });
+    lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          errors: 1,
+          html: `<img class="  b  a \n c  \n a d  " />`,
+          htmlOutput: `<img class="  b  a \n c  \n  d  " />`,
+          jsx: `() => <img class="  b  a \n c  \n a d  " />`,
+          jsxOutput: `() => <img class="  b  a \n c  \n  d  " />`,
+          svelte: `<img class="  b  a \n c  \n a d  " />`,
+          svelteOutput: `<img class="  b  a \n c  \n  d  " />`,
+          vue: `<template><img class="  b  a \n c  \n a d  " /></template>`,
+          vueOutput: `<template><img class="  b  a \n c  \n  d  " /></template>`
+        }
+      ]
+    });
+  });
+
+
 });


### PR DESCRIPTION
fixes #81 

The eslint vue parser internally converts all windows style line breaks to unix: https://github.com/vuejs/vue-eslint-parser/blob/01ed265959a71d6ca819830529021e1f2e261e1b/src/html/tokenizer.ts#L337-L342

This causes all rules to report warnings because they are comparing the original raw input that contain the`\r` characters to the altered string literals containing only the`\n` character.

```vue
<template><img class="a b \r\n c d" /></template> -> <template><img class="a b \n c d" /></template>
```