### PR TITLE
refactor: detect potential misconfiguration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,12 +21,13 @@
     "eslintrc",
     "espree",
     "estree",
+    "jiti",
     "linebreak",
+    "linebreakstyle",
     "objstr",
     "OBJSTR",
     "quasis",
     "shadcn",
-    "synckit",
-    "jiti"
+    "synckit"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -106,8 +106,25 @@ npm i -D eslint-plugin-readable-tailwind
 
 ## Quick start
 
-1. Follow the [Parsers](#parsers) section below to learn how to configure the plugin for your specific requirements.
-1. Read the [Rules](#rules) section to learn about the available rules and how to configure them.
+1. Follow the [parsers](#parsers) section below to learn how to configure the plugin for your specific requirements.
+
+1. Configure the plugin to be able to read your tailwind configuration via [settings](docs/settings/settings.md) or for each [rule](#rules) separately.
+
+    ```jsonc
+    // eslint.config.js
+    {
+      //...
+      "settings": {
+        "readable-tailwind": {
+          // tailwindcss 4: the path to the entry file of the css based tailwind config (eg: `src/global.css`)
+          "entryPoint": "src/global.css",
+          // tailwindcss 3: the path to the tailwind config file (eg: `tailwind.config.js`)
+          "tailwindConfig": "tailwind.config.js"
+        }
+      }
+    }
+    ```
+
 1. Configure your editor to conveniently [auto-fix on save](#auto-fix-on-save).
 
 <br/>

--- a/src/rules/tailwind-no-duplicate-classes.ts
+++ b/src/rules/tailwind-no-duplicate-classes.ts
@@ -47,6 +47,8 @@ const defaultOptions = {
   variables: DEFAULT_VARIABLE_NAMES
 } as const satisfies Options[0];
 
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/rules/no-duplicate-classes.md";
+
 export const tailwindNoDuplicateClasses: ESLintRule<Options> = {
   name: "no-duplicate-classes" as const,
   rule: {
@@ -56,7 +58,7 @@ export const tailwindNoDuplicateClasses: ESLintRule<Options> = {
         category: "Stylistic Issues",
         description: "Disallow duplicate class names in tailwind classes.",
         recommended: true,
-        url: "https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/rules/no-duplicate-classes.md"
+        url: DOCUMENTATION_URL
       },
       fixable: "code",
       schema: [

--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -46,6 +46,8 @@ const defaultOptions = {
   variables: DEFAULT_VARIABLE_NAMES
 } as const satisfies Options[0];
 
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/rules/no-unnecessary-whitespace.md";
+
 export const tailwindNoUnnecessaryWhitespace: ESLintRule<Options> = {
   name: "no-unnecessary-whitespace" as const,
   rule: {
@@ -55,7 +57,7 @@ export const tailwindNoUnnecessaryWhitespace: ESLintRule<Options> = {
         category: "Stylistic Issues",
         description: "Disallow unnecessary whitespace in tailwind classes.",
         recommended: true,
-        url: "https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/rules/no-unnecessary-whitespace.md"
+        url: DOCUMENTATION_URL
       },
       fixable: "whitespace",
       schema: [

--- a/src/tailwind/api/interface.ts
+++ b/src/tailwind/api/interface.ts
@@ -1,7 +1,12 @@
+import type { Warning } from "readable-tailwind:utils:utils.js";
+
+
 export interface GetClassOrderRequest {
   classes: string[];
   cwd: string;
   configPath?: string;
 }
 
-export type GetClassOrderResponse = [className: string, order: bigint | null][];
+export type ConfigWarning = Omit<Warning, "url"> & Partial<Pick<Warning, "url">>;
+
+export type GetClassOrderResponse = [classOrder: [className: string, order: bigint | null][], warnings: ConfigWarning[]];

--- a/src/tailwind/v3/class-order.ts
+++ b/src/tailwind/v3/class-order.ts
@@ -1,11 +1,21 @@
 import { findTailwindConfig } from "./config.js";
 import { createTailwindContextFromConfigFile } from "./context.js";
 
-import type { GetClassOrderRequest, GetClassOrderResponse } from "../api/interface.js";
+import type { ConfigWarning, GetClassOrderRequest, GetClassOrderResponse } from "../api/interface.js";
 
 
 export async function getClassOrder({ classes, configPath, cwd }: GetClassOrderRequest): Promise<GetClassOrderResponse> {
+  const warnings: ConfigWarning[] = [];
+
   const config = findTailwindConfig(cwd, configPath);
+
+  if(!config){
+    warnings.push({
+      option: "entryPoint",
+      title: `No tailwind css config found at \`${configPath}\``
+    });
+  }
+
   const context = createTailwindContextFromConfigFile(config?.path, config?.invalidate);
-  return context.getClassOrder(classes);
+  return [context.getClassOrder(classes), warnings];
 }

--- a/src/tailwind/v4/class-order.ts
+++ b/src/tailwind/v4/class-order.ts
@@ -1,11 +1,31 @@
-import { findTailwindConfig } from "./config.js";
+import { findDefaultConfig, findTailwindConfig } from "./config.js";
 import { createTailwindContextFromEntryPoint } from "./context.js";
 
-import type { GetClassOrderRequest, GetClassOrderResponse } from "../api/interface.js";
+import type { ConfigWarning, GetClassOrderRequest, GetClassOrderResponse } from "../api/interface.js";
 
 
 export async function getClassOrder({ classes, configPath, cwd }: GetClassOrderRequest): Promise<GetClassOrderResponse> {
-  const { invalidate, path } = findTailwindConfig(cwd, configPath);
+  const warnings: ConfigWarning[] = [];
+
+  const config = findTailwindConfig(cwd, configPath);
+  const defaultConfig = findDefaultConfig(cwd);
+
+  if(!config){
+    warnings.push({
+      option: "entryPoint",
+      title: configPath
+        ? `No tailwind css config found at \`${configPath}\``
+        : "No tailwind css entry point configured"
+    });
+  }
+
+  const path = config?.path ?? defaultConfig.path;
+  const invalidate = config?.invalidate ?? defaultConfig.invalidate;
+
+  if(!path){
+    throw new Error("Could not find a valid Tailwind CSS configuration");
+  }
+
   const context = await createTailwindContextFromEntryPoint(path, invalidate);
-  return context.getClassOrder(classes);
+  return [context.getClassOrder(classes), warnings];
 }

--- a/src/tailwind/v4/config.ts
+++ b/src/tailwind/v4/config.ts
@@ -6,31 +6,15 @@ export function findTailwindConfig(cwd: string, configPath?: string) {
   const potentialStylesheetPaths = [
     ...configPath ? [configPath] : []
   ];
-  const potentialConfigPaths = [
-    ...configPath ? [configPath] : [],
-    "tailwind.config.js",
-    "tailwind.config.cjs",
-    "tailwind.config.mjs",
-    "tailwind.config.ts"
-  ];
 
-  const foundStylesheetPath = findFileRecursive(cwd, potentialStylesheetPaths);
-  const foundConfigPath = findFileRecursive(cwd, potentialConfigPaths);
+  return findFileRecursive(cwd, potentialStylesheetPaths);
+}
 
-  const path = foundStylesheetPath ?? foundConfigPath;
+export function findDefaultConfig(cwd: string) {
+  const defaultStyleSheetPath = cssResolver.resolveSync({}, cwd, "tailwindcss/theme.css");
 
-  if(!path){
-    const defaultStyleSheetPath = cssResolver.resolveSync({}, cwd, "tailwindcss/theme.css");
-
-    if(defaultStyleSheetPath){
-      return {
-        invalidate: false,
-        path: defaultStyleSheetPath
-      };
-    }
-
-    throw new Error("Could not find a valid Tailwind CSS configuration");
-  }
-
-  return path;
+  return {
+    invalidate: false,
+    path: defaultStyleSheetPath
+  };
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -69,6 +69,26 @@ export function display(classes: string): string {
     .replaceAll("\t", "→");
 }
 
+export interface Warning<Options extends Record<string, any> = Record<string, any>> {
+  option: keyof Options;
+  title: string;
+  url: string;
+}
+
+export function augmentMessageWithWarnings(message: string, warnings?: Warning[]) {
+  if(!warnings || warnings.length === 0){
+    return message;
+  }
+
+  return [
+    warnings.flatMap(({ option, title, url }) => [
+      `⚠️ Warning: ${title}. Option \`${option}\` may be misconfigured.`,
+      `Check documentation at ${url}`
+    ]).join("\n"),
+    message
+  ].join("\n\n");
+}
+
 export function splitWhitespaces(classes: string): string[] {
   return classes.split(/\S+/);
 }


### PR DESCRIPTION
I have noticed that many users don’t configure the plugin correctly, in particular, the `lineBreakStyle` option, which often leads to avoidable issues.

With this PR, the rules can now detect potential misconfiguration by comparing the differences of the input string and the configured `lineBreakStyle` or `indent` options and prepends a warning if something doesn't match.