### PR TITLE
fix: carriage return in es literals when processed via vue parser

### DIFF
--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -16,7 +16,13 @@ import {
   matchesPathPattern
 } from "readable-tailwind:utils:matchers.js";
 import { getLiteralsByESNodeAndRegex } from "readable-tailwind:utils:regex.js";
-import { deduplicateLiterals, getQuotes, getWhitespace, matchesName } from "readable-tailwind:utils:utils.js";
+import {
+  deduplicateLiterals,
+  getContent,
+  getQuotes,
+  getWhitespace,
+  matchesName
+} from "readable-tailwind:utils:utils.js";
 
 import type { Rule } from "eslint";
 import type {
@@ -168,15 +174,15 @@ export function getLiteralNodesByRegex(ctx: Rule.RuleContext, node: ESNode, rege
 export function getStringLiteralByESStringLiteral(ctx: Rule.RuleContext, node: ESSimpleStringLiteral): StringLiteral | undefined {
 
   const raw = node.raw;
-  const content = node.value;
 
   if(!raw || !node.loc || !node.range || !node.parent.loc || !node.parent.range){
     return;
   }
 
   const quotes = getQuotes(raw);
-  const whitespaces = getWhitespace(content);
   const priorLiterals = findPriorLiterals(ctx, node);
+  const content = getContent(raw, quotes);
+  const whitespaces = getWhitespace(content);
 
   return {
     ...quotes,
@@ -196,16 +202,16 @@ export function getStringLiteralByESStringLiteral(ctx: Rule.RuleContext, node: E
 function getLiteralByESTemplateElement(ctx: Rule.RuleContext, node: ESTemplateElement & Rule.Node): TemplateLiteral | undefined {
 
   const raw = ctx.sourceCode.getText(node);
-  const content = node.value.raw;
 
   if(!raw || !node.loc || !node.range || !node.parent.loc || !node.parent.range){
     return;
   }
 
   const quotes = getQuotes(raw);
-  const whitespaces = getWhitespace(content);
   const braces = getBracesByString(ctx, raw);
   const priorLiterals = findPriorLiterals(ctx, node);
+  const content = getContent(raw, quotes, braces);
+  const whitespaces = getWhitespace(content);
 
   return {
     ...whitespaces,

--- a/src/parsers/html.ts
+++ b/src/parsers/html.ts
@@ -1,5 +1,5 @@
 import { isAttributesMatchers, isAttributesName, isAttributesRegex } from "readable-tailwind:utils:matchers.js";
-import { deduplicateLiterals, matchesName } from "readable-tailwind:utils:utils.js";
+import { deduplicateLiterals, getContent, matchesName } from "readable-tailwind:utils:utils.js";
 
 import type { AttributeNode, TagNode } from "es-html-parser";
 import type { Rule } from "eslint";
@@ -39,15 +39,16 @@ export function getLiteralsByHTMLAttributeNode(ctx: Rule.RuleContext, attribute:
   }
 
   const raw = attribute.startWrapper?.value + value.value + attribute.endWrapper?.value;
-  const { closingQuote, openingQuote } = getQuotesByHTMLAttribute(ctx, attribute);
+
+  const quotes = getQuotesByHTMLAttribute(ctx, attribute);
+  const content = getContent(raw, quotes);
 
   return [{
-    closingQuote,
-    content: value.value,
+    ...quotes,
+    content,
     loc: value.loc,
     // @ts-expect-error - Missing in types
     node: attribute,
-    openingQuote,
     // @ts-expect-error - Missing in types
     parent: attribute.parent,
     range: [value.range[0] - 1, value.range[1] + 1], // include quotes in range

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -17,7 +17,13 @@ import {
   matchesPathPattern
 } from "readable-tailwind:utils:matchers.js";
 import { getLiteralsByESNodeAndRegex } from "readable-tailwind:utils:regex.js";
-import { deduplicateLiterals, getQuotes, getWhitespace, matchesName } from "readable-tailwind:utils:utils.js";
+import {
+  deduplicateLiterals,
+  getContent,
+  getQuotes,
+  getWhitespace,
+  matchesName
+} from "readable-tailwind:utils:utils.js";
 
 import type { Rule } from "eslint";
 import type { BaseNode as ESBaseNode, Node as ESNode } from "estree";
@@ -114,10 +120,10 @@ function getLiteralsBySvelteLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode)
 
 function getStringLiteralBySvelteStringLiteral(ctx: Rule.RuleContext, node: SvelteLiteral): StringLiteral | undefined {
 
-  const content = node.value;
   const raw = ctx.sourceCode.getText(node as unknown as ESNode, 1, 1);
 
   const quotes = getQuotes(raw);
+  const content = getContent(raw, quotes);
   const whitespaces = getWhitespace(content);
 
   return {

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -17,7 +17,13 @@ import {
   matchesPathPattern
 } from "readable-tailwind:utils:matchers.js";
 import { getLiteralsByESNodeAndRegex } from "readable-tailwind:utils:regex.js";
-import { deduplicateLiterals, getQuotes, getWhitespace, matchesName } from "readable-tailwind:utils:utils.js";
+import {
+  deduplicateLiterals,
+  getContent,
+  getQuotes,
+  getWhitespace,
+  matchesName
+} from "readable-tailwind:utils:utils.js";
 
 import type { Rule } from "eslint";
 import type { BaseNode as ESBaseNode, Node as ESNode } from "estree";
@@ -54,9 +60,7 @@ export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.
     return literals;
   }, []);
 
-  return deduplicateLiterals(literals.map(
-    literal => overrideLiteralContent(literal, literal.content)
-  ));
+  return deduplicateLiterals(literals);
 
 }
 
@@ -88,10 +92,10 @@ function getLiteralsByVueMatchers(ctx: Rule.RuleContext, node: ESBaseNode, match
 
 function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLiteral): StringLiteral {
 
-  const content = node.value;
   const raw = ctx.sourceCode.getText(node as unknown as ESNode);
-  const quotes = getQuotes(raw);
 
+  const quotes = getQuotes(raw);
+  const content = getContent(raw, quotes);
   const whitespaces = getWhitespace(content);
 
   return {

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -48,6 +48,7 @@ interface LiteralBase extends NodeBase, Meta, Range, Loc {
   content: string;
   node: Node;
   raw: string;
+  priorLiterals?: Literal[];
 }
 
 export interface TemplateLiteral extends LiteralBase, Node {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ import {
 
 import type { Rule } from "eslint";
 
-import type { Literal, Node, QuoteMeta } from "readable-tailwind:types:ast.js";
+import type { BracesMeta, Literal, Node, QuoteMeta } from "readable-tailwind:types:ast.js";
 
 
 export function getCommonOptions(ctx: Rule.RuleContext) {
@@ -47,6 +47,13 @@ export function getQuotes(raw: string): QuoteMeta {
     closingQuote: closingQuote === "'" || closingQuote === '"' || closingQuote === "`" ? closingQuote : undefined,
     openingQuote: openingQuote === "'" || openingQuote === '"' || openingQuote === "`" ? openingQuote : undefined
   };
+}
+
+export function getContent(raw: string, quotes?: QuoteMeta, braces?: BracesMeta) {
+  return raw.substring(
+    (quotes?.openingQuote?.length ?? 0) + (braces?.closingBraces?.length ?? 0),
+    raw.length - (quotes?.closingQuote?.length ?? 0) - (braces?.openingBraces?.length ?? 0)
+  );
 }
 
 export function splitClasses(classes: string): string[] {


### PR DESCRIPTION
Another fix for #81. Normal ES literals also lack the `\r` character in the node content when processed via the vue eslint parser.

See: https://github.com/schoero/eslint-plugin-readable-tailwind/pull/82