### PR TITLE
fix: unnecessarily escaped quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-- Unnecessarily escaped quotes in autofixed classes ([de63d11](https://github.com/schoero/eslint-plugin-readable-tailwind/commit/de63d11))
+- Unnecessarily escaped quotes in autofixed classes ([#88](https://github.com/schoero/eslint-plugin-readable-tailwind/pull/88))
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.1.1
+
+[compare changes](https://github.com/schoero/eslint-plugin-readable-tailwind/compare/v2.1.0...v2.1.1)
+
+### Fixes
+
+- Unnecessarily escaped quotes in autofixed classes ([de63d11](https://github.com/schoero/eslint-plugin-readable-tailwind/commit/de63d11))
+
 ## v2.1.0
 
 [compare changes](https://github.com/schoero/eslint-plugin-readable-tailwind/compare/v2.0.1...v2.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-readable-tailwind",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-readable-tailwind",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "name": "eslint-plugin-readable-tailwind",
   "description": "auto-wraps tailwind classes after a certain print width or class count into multiple lines to improve readability.",

--- a/src/rules/tailwind-multiline.ts
+++ b/src/rules/tailwind-multiline.ts
@@ -633,7 +633,7 @@ class Line {
       this.meta.leadingWhitespace ?? "",
       escapeNestedQuotes(
         this.join(this.classes),
-        this.meta.openingQuote ?? "`"
+        this.meta.openingQuote ?? this.meta.closingQuote ?? "`"
       ),
       this.meta.trailingWhitespace ?? "",
       this.meta.openingBraces,

--- a/src/rules/tailwind-no-duplicate-classes.ts
+++ b/src/rules/tailwind-no-duplicate-classes.ts
@@ -127,7 +127,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
     const escapedClasses = escapeNestedQuotes(
       finalChunks.join(""),
-      literal.openingQuote ?? "\""
+      literal.openingQuote ?? literal.closingQuote ?? "\""
     );
 
     const fixedClasses = [

--- a/src/rules/tailwind-no-unnecessary-whitespace.ts
+++ b/src/rules/tailwind-no-unnecessary-whitespace.ts
@@ -92,7 +92,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
     const escapedClasses = escapeNestedQuotes(
       classes.join(""),
-      literal.openingQuote ?? "`"
+      literal.openingQuote ?? literal.closingQuote ?? "`"
     );
 
     const fixedClasses = [

--- a/src/rules/tailwind-sort-classes.ts
+++ b/src/rules/tailwind-sort-classes.ts
@@ -140,7 +140,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         ...classes,
         unsortableClasses[1]
       ].join(""),
-      literal.openingQuote ?? "`"
+      literal.openingQuote ?? literal.closingQuote ?? "`"
     );
 
     const fixedClasses =


### PR DESCRIPTION
Fixes an issue where the autofixed classes would contain unnecessarily escaped quotes when the class was in a template element after an interpolated template element:

```diff
  const Test = (isActive: boolean) => (
    <span
      class={`
        ${isActive ? "text-red-500!" : ""}
-       group-[[data-state=\"open\"]]/collapsible:text-red-500
+       group-[[data-state="open"]]/collapsible:text-red-500
      `}
    >
      Test
    </span>
);
```