### PR TITLE
refactor: report error for each duplicate instead of the whole string

### DIFF
--- a/src/rules/tailwind-no-duplicate-classes.test.ts
+++ b/src/rules/tailwind-no-duplicate-classes.test.ts
@@ -220,7 +220,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 3,
           jsx: `() => <img class={\`${dirtyExpressionBetween}\`} />`,
           jsxOutput: `() => <img class={\`${cleanExpressionBetween}\`} />`,
           svelte: `<img class={\`${dirtyExpressionBetween}\`} />`,
@@ -260,7 +260,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 4,
           jsx: `() => <img class={\`${dirtyStickyExpressionAtStart}\`} />`,
           jsxOutput: `() => <img class={\`${cleanStickyExpressionAtStart}\`} />`,
           svelte: `<img class={\`${dirtyStickyExpressionAtStart}\`} />`,
@@ -272,7 +272,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 4,
           jsx: `() => <img class={\`${dirtyStickyExpressionBetween}\`} />`,
           jsxOutput: `() => <img class={\`${cleanStickyExpressionBetween}\`} />`,
           svelte: `<img class={\`${dirtyStickyExpressionBetween}\`} />`,
@@ -285,7 +285,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 4,
           jsx: `() => <img class={\`${dirtyStickyExpressionAtEnd}\`} />`,
           jsxOutput: `() => <img class={\`${cleanStickyExpressionAtEnd}\`} />`,
           svelte: `<img class={\`${dirtyStickyExpressionAtEnd}\`} />`,
@@ -313,7 +313,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 4,
           jsx: `() => <img class={\`${dirtyStickyExpressionAtStart}\`} />`,
           jsxOutput: `() => <img class={\`${cleanStickyExpressionAtStart}\`} />`,
           svelte: `<img class={\`${dirtyStickyExpressionAtStart}\`} />`,
@@ -325,7 +325,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 4,
           jsx: `() => <img class={\`${dirtyStickyExpressionBetween}\`} />`,
           jsxOutput: `() => <img class={\`${cleanStickyExpressionBetween}\`} />`,
           svelte: `<img class={\`${dirtyStickyExpressionBetween}\`} />`,
@@ -338,7 +338,7 @@ describe(tailwindNoDuplicateClasses.name, () => {
     lint(tailwindNoDuplicateClasses, TEST_SYNTAXES, {
       invalid: [
         {
-          errors: 2,
+          errors: 4,
           jsx: `() => <img class={\`${dirtyStickyExpressionAtEnd}\`} />`,
           jsxOutput: `() => <img class={\`${cleanStickyExpressionAtEnd}\`} />`,
           svelte: `<img class={\`${dirtyStickyExpressionAtEnd}\`} />`,

--- a/src/rules/tailwind-no-duplicate-classes.ts
+++ b/src/rules/tailwind-no-duplicate-classes.ts
@@ -12,7 +12,12 @@ import {
 } from "readable-tailwind:options:descriptions.js";
 import { escapeNestedQuotes } from "readable-tailwind:utils:quotes.js";
 import { createRuleListener } from "readable-tailwind:utils:rule.js";
-import { getCommonOptions, splitClasses, splitWhitespaces } from "readable-tailwind:utils:utils.js";
+import {
+  getCommonOptions,
+  getExactClassLocation,
+  splitClasses,
+  splitWhitespaces
+} from "readable-tailwind:utils:utils.js";
 
 import type { Rule } from "eslint";
 
@@ -142,16 +147,18 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       continue;
     }
 
-    ctx.report({
-      data: {
-        duplicateClassname: duplicates.join(", ")
-      },
-      fix(fixer) {
-        return fixer.replaceTextRange(literal.range, fixedClasses);
-      },
-      loc: literal.loc,
-      message: "Duplicate classname: \"{{ duplicateClassname }}\"."
-    });
+    for(const className of duplicates){
+      ctx.report({
+        data: {
+          duplicateClassname: className
+        },
+        fix(fixer) {
+          return fixer.replaceTextRange(literal.range, fixedClasses);
+        },
+        loc: getExactClassLocation(literal, className, true),
+        message: "Duplicate classname: \"{{ duplicateClassname }}\"."
+      });
+    }
 
   }
 

--- a/tests/e2e/commonjs/test.test.ts
+++ b/tests/e2e/commonjs/test.test.ts
@@ -21,9 +21,9 @@ describe("e2e/commonjs", async () => {
 
     expect(json.messages.map(({ ruleId }) => ruleId)).toEqual([
       "readable-tailwind/multiline",
-      "readable-tailwind/no-duplicate-classes",
       "readable-tailwind/no-unnecessary-whitespace",
-      "readable-tailwind/sort-classes"
+      "readable-tailwind/sort-classes",
+      "readable-tailwind/no-duplicate-classes"
     ]);
 
   });

--- a/tests/e2e/esm/test.test.ts
+++ b/tests/e2e/esm/test.test.ts
@@ -21,9 +21,9 @@ describe("e2e/esm", async () => {
 
     expect(json.messages.map(({ ruleId }) => ruleId)).toEqual([
       "readable-tailwind/multiline",
-      "readable-tailwind/no-duplicate-classes",
       "readable-tailwind/no-unnecessary-whitespace",
-      "readable-tailwind/sort-classes"
+      "readable-tailwind/sort-classes",
+      "readable-tailwind/no-duplicate-classes"
     ]);
 
   });


### PR DESCRIPTION
Now reports errors in [`no-duplicate-classes`](https://github.com/schoero/eslint-plugin-readable-tailwind/blob/main/docs/rules/no-duplicate-classes.md) rule for each duplicate class instead of the whole class string.

```tsx
// Before:
<div class="grid grid" />;
            ~~~~~~~~~

// After:
<div class="grid grid" />;
                 ~~~~
```
