### PR TITLE
feat: no-restricted-classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The following table shows the available rules, the supported tailwindcss version
 | [no-unnecessary-whitespace](docs/rules/no-unnecessary-whitespace.md) | Disallow unnecessary whitespace in tailwind classes. | ✔ | ✔ | ✔ | ✔ | ✔ |
 | [sort-classes](docs/rules/sort-classes.md) | Enforce a consistent order for tailwind classes. | ✔ | ✔ | ✔ | ✔ | ✔ |
 | [no-duplicate-classes](docs/rules/no-duplicate-classes.md) | Remove duplicate classes. | ✔ | ✔ | ✔ | ✔ | ✔ |
+| [no-restricted-classes](docs/rules/no-restricted-classes.md) | Disallow restricted classes. | ✔ | ✔ |  |  |  |
 
 <br/>
 <br/>

--- a/docs/rules/no-restricted-classes.md
+++ b/docs/rules/no-restricted-classes.md
@@ -1,0 +1,68 @@
+# better-tailwindcss/no-restricted-classes
+
+Disallow the usage of certain classes. This can be useful to disallow classes that are not recommended to be used in your project. For example, you can disallow the use of the child variants (`*:`) or the `!important` modifier (`!`) in your project.
+
+<br/>
+
+## Options
+
+### `restrict`
+
+  The classes that should be disallowed. The entries in this list are treated as regular expressions.
+
+  **Type**: `string[]`  
+  **Default**: `[]`
+
+<br/>
+
+### `attributes`
+
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md#attributes).  
+
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: [Name](../concepts/concepts.md#name) for `"class"` and [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"class", "className"`
+
+<br/>
+
+### `callees`
+
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md#callees).  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: [Matchers](../concepts/concepts.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
+
+<br/>
+
+### `variables`
+
+  List of variable names whose initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md#variables).  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**:  [strings Matcher](../concepts/concepts.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+<br/>
+
+### `tags`
+
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md#tags).  
+  
+  **Type**: Array of [Name](../concepts/concepts.md#name), [Regex](../concepts/concepts.md#regular-expressions) or [Matchers](../concepts/concepts.md#matchers)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../concepts/concepts.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
+
+<br/>
+
+## Examples
+
+```tsx
+// ❌ BAD: disallow the use of the child variants with option `{ restrict: ["^\\*+:.*"] }`
+<div class="rounded *:mx-0" />;
+//                  ~~~~~~
+```
+
+```tsx
+// ❌ BAD: disallow the use of the important modifier `{ restrict: ["^.*!$"] }`
+<div class="rounded p-4!" />;
+//                  ~~~~
+```

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -1,5 +1,6 @@
 import { tailwindMultiline } from "better-tailwindcss:rules:tailwind-multiline.js";
 import { tailwindNoDuplicateClasses } from "better-tailwindcss:rules:tailwind-no-duplicate-classes.js";
+import { tailwindNoRestrictedClasses } from "better-tailwindcss:rules:tailwind-no-restricted-classes.js";
 import { tailwindNoUnnecessaryWhitespace } from "better-tailwindcss:rules:tailwind-no-unnecessary-whitespace.js";
 import { tailwindSortClasses } from "better-tailwindcss:rules:tailwind-sort-classes.js";
 
@@ -30,6 +31,7 @@ export const config = {
   rules: {
     [tailwindMultiline.name]: tailwindMultiline.rule,
     [tailwindNoDuplicateClasses.name]: tailwindNoDuplicateClasses.rule,
+    [tailwindNoRestrictedClasses.name]: tailwindNoRestrictedClasses.rule,
     [tailwindNoUnnecessaryWhitespace.name]: tailwindNoUnnecessaryWhitespace.rule,
     [tailwindSortClasses.name]: tailwindSortClasses.rule
   }

--- a/src/rules/tailwind-no-restricted-classes.test.ts
+++ b/src/rules/tailwind-no-restricted-classes.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "vitest";
+
+import { tailwindNoRestrictedClasses } from "better-tailwindcss:rules:tailwind-no-restricted-classes.js";
+import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests:utils.js";
+
+
+describe(tailwindNoRestrictedClasses.name, () => {
+
+  it("should not report on unrestricted classes", () => {
+    lint(tailwindNoRestrictedClasses, TEST_SYNTAXES, {
+      valid: [
+        {
+          angular: `<img class="font-bold container text-lg" />`,
+          html: `<img class="font-bold container text-lg" />`,
+          jsx: `() => <img class="font-bold container text-lg" />`,
+          svelte: `<img class="font-bold container text-lg" />`,
+          vue: `<template><img class="font-bold container text-lg" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report restricted classes", () => {
+    lint(tailwindNoRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold container text-lg" />`,
+          errors: 1,
+          html: `<img class="font-bold container text-lg" />`,
+          jsx: `() => <img class="font-bold container text-lg" />`,
+          options: [{ restrict: ["container"] }],
+          svelte: `<img class="font-bold container text-lg" />`,
+          vue: `<template><img class="font-bold container text-lg" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report restricted classes matching a regex", () => {
+    lint(tailwindNoRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold container text-lg" />`,
+          errors: 1,
+          html: `<img class="font-bold container text-lg" />`,
+          jsx: `() => <img class="font-bold container text-lg" />`,
+          options: [{ restrict: ["^container$"] }],
+          svelte: `<img class="font-bold container text-lg" />`,
+          vue: `<template><img class="font-bold container text-lg" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report restricted classes with variants", () => {
+    lint(tailwindNoRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold lg:container lg:text-lg" />`,
+          errors: 2,
+          html: `<img class="font-bold lg:container lg:text-lg" />`,
+          jsx: `() => <img class="font-bold lg:container lg:text-lg" />`,
+          options: [{ restrict: ["^lg:.*"] }],
+          svelte: `<img class="font-bold lg:container lg:text-lg" />`,
+          vue: `<template><img class="font-bold lg:container lg:text-lg" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report restricted classes containing reserved regex characters", () => {
+    lint(tailwindNoRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold *:container **:text-lg" />`,
+          errors: 2,
+          html: `<img class="font-bold *:container **:text-lg" />`,
+          jsx: `() => <img class="font-bold *:container **:text-lg" />`,
+          options: [{ restrict: ["^\\*+:.*"] }],
+          svelte: `<img class="font-bold *:container **:text-lg" />`,
+          vue: `<template><img class="font-bold *:container **:text-lg" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should be possible to disallow the important modifier", () => {
+    lint(tailwindNoRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold text-lg!" />`,
+          errors: 1,
+          html: `<img class="font-bold text-lg!" />`,
+          jsx: `() => <img class="font-bold text-lg!" />`,
+          options: [{ restrict: ["^.*!$"] }],
+          svelte: `<img class="font-bold text-lg!" />`,
+          vue: `<template><img class="font-bold text-lg!" /></template>`
+        }
+      ]
+    });
+  });
+
+});

--- a/src/rules/tailwind-no-restricted-classes.ts
+++ b/src/rules/tailwind-no-restricted-classes.ts
@@ -1,0 +1,123 @@
+import {
+  DEFAULT_ATTRIBUTE_NAMES,
+  DEFAULT_CALLEE_NAMES,
+  DEFAULT_TAG_NAMES,
+  DEFAULT_VARIABLE_NAMES
+} from "better-tailwindcss:options:default-options.js";
+import {
+  ATTRIBUTE_SCHEMA,
+  CALLEE_SCHEMA,
+  TAG_SCHEMA,
+  VARIABLE_SCHEMA
+} from "better-tailwindcss:options:descriptions.js";
+import { createRuleListener } from "better-tailwindcss:utils:rule.js";
+import { getCommonOptions, getExactClassLocation, splitClasses } from "better-tailwindcss:utils:utils.js";
+
+import type { Rule } from "eslint";
+
+import type { Literal } from "better-tailwindcss:types:ast.js";
+import type {
+  AttributeOption,
+  CalleeOption,
+  ESLintRule,
+  TagOption,
+  VariableOption
+} from "better-tailwindcss:types:rule.js";
+
+
+export type Options = [
+  Partial<
+    AttributeOption &
+    CalleeOption &
+    TagOption &
+    VariableOption &
+    {
+      restrict?: string[];
+    }
+  >
+];
+
+const defaultOptions = {
+  attributes: DEFAULT_ATTRIBUTE_NAMES,
+  callees: DEFAULT_CALLEE_NAMES,
+  restrict: [],
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/no-restricted-classes.md";
+
+export const tailwindNoRestrictedClasses: ESLintRule<Options> = {
+  name: "no-restricted-classes" as const,
+  rule: {
+    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    meta: {
+      docs: {
+        description: "Disallow restricted classes.",
+        recommended: false,
+        url: DOCUMENTATION_URL
+      },
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            ...CALLEE_SCHEMA,
+            ...ATTRIBUTE_SCHEMA,
+            ...VARIABLE_SCHEMA,
+            ...TAG_SCHEMA,
+            restrict: {
+              items: {
+                type: "string"
+              },
+              type: "array"
+            }
+          },
+          type: "object"
+        }
+      ],
+      type: "problem"
+    }
+  }
+};
+
+
+function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
+
+  const { restrict: restrictions } = getOptions(ctx);
+
+  for(const literal of literals){
+    const classes = literal.content;
+
+    const classNames = splitClasses(classes);
+    const restrict = classNames.filter(className => {
+      return restrictions.some(restriction => className.match(restriction));
+    });
+
+    for(const restrictedClass of restrict){
+      ctx.report({
+        data: {
+          restrictedClass
+        },
+        loc: getExactClassLocation(literal, restrictedClass),
+        message: "Restricted class: \"{{ restrictedClass }}\"."
+      });
+    }
+
+  }
+
+}
+
+export function getOptions(ctx: Rule.RuleContext) {
+
+  const options: Options[0] = ctx.options[0] ?? {};
+
+  const common = getCommonOptions(ctx);
+
+  const restrict = options.restrict ?? defaultOptions.restrict;
+
+  return {
+    ...common,
+    restrict
+  };
+
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -64,7 +64,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, Li
 
       const ruleTester = new RuleTester(syntaxes[syntax]);
 
-      if(!invalid[syntax] || !invalid[`${syntax}Output`]){
+      if(!invalid[syntax]){
         continue;
       }
 
@@ -73,7 +73,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, Li
           code: invalid[syntax],
           errors: invalid.errors,
           options: invalid.options ?? [],
-          output: invalid[`${syntax}Output`]!,
+          output: invalid[`${syntax}Output`] ?? null,
           settings: invalid.settings ?? {}
         }],
         valid: []


### PR DESCRIPTION
New rule to disallow tailwindcss classes

```tsx
// ❌ BAD: disallow the use of the child variants with option `{ restrict: ["^\\*+:.*"] }`
<div class="rounded *:mx-0" />;
//                  ~~~~~~
```

```tsx
// ❌ BAD: disallow the use of the important modifier `{ restrict: ["^.*!$"] }`
<div class="rounded p-4!" />;
//                  ~~~~
```
