### PR TITLE
Handle TemplateElement nodes in getESObjectPath

### DIFF
--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -375,7 +375,8 @@ export function getESObjectPath(node: ESNode & Partial<Rule.NodeParentExtension>
     node.type !== "ObjectExpression" &&
     node.type !== "ArrayExpression" &&
     node.type !== "Identifier" &&
-    node.type !== "Literal"
+    node.type !== "Literal" &&
+    node.type !== "TemplateElement"
   ){
     return;
   }
@@ -405,7 +406,7 @@ export function getESObjectPath(node: ESNode & Partial<Rule.NodeParentExtension>
     return getESObjectPath(property);
   }
 
-  if(node.parent.type === "ArrayExpression" && node.type !== "Property"){
+  if(node.parent.type === "ArrayExpression" && node.type !== "Property" && node.type !== "TemplateElement"){
     const index = node.parent.elements.indexOf(node);
     paths.unshift(`[${index}]`);
   }

--- a/src/utils/matchers.test.ts
+++ b/src/utils/matchers.test.ts
@@ -70,6 +70,29 @@ describe("matchers", () => {
 
       });
 
+      it("should return the correct object path for template literal values", () => {
+
+        const code = `const obj = {
+          root: {
+            nested: {
+              value: \`value\`
+            }
+          }
+        };`;
+
+        const ast = withParentNodeExtension(parse(code, { ecmaVersion: "latest" }) as ESNode);
+
+        const value = findNode(ast, (node): node is ESNode => {
+          return isESNode(node) && isESStringLike(node) && isInsideObjectValue(node);
+        });
+
+        assert(value);
+
+        const path = getESObjectPath(value);
+        expect(path).toBe("root.nested.value");
+
+      });
+
       it("should put names in quotes if they are not valid identifiers", () => {
 
         const code = `const obj = {


### PR DESCRIPTION
Fixes #141 

Extend getESObjectPath to support TemplateElement nodes, ensuring correct object path resolution for template literal values. Added a test to verify object path extraction for template literals.