### PR TITLE
fix(enforce-consistent-variable-syntax): false positives with multiple vars

### DIFF
--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -1054,4 +1054,24 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
+  it("should not convert if multiple variables are used in the same class", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="object-[var(--x)_var(--y)]" />`,
+            html: `<img class="object-[var(--x)_var(--y)]" />`,
+            jsx: `() => <img class="object-[var(--x)_var(--y)]" />`,
+            svelte: `<img class="object-[var(--x)_var(--y)]" />`,
+            vue: `<template><img class="object-[var(--x)_var(--y)]" /></template>`,
+
+            options: [{ syntax: "shorthand" }]
+          }
+        ]
+      }
+    );
+  });
+
 });

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -129,7 +129,11 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
         if(isBeginningOfArbitraryVariable(charactersSquareBrackets)){
 
-          const { characters } = extractBalanced(charactersSquareBrackets);
+          const { after, characters } = extractBalanced(charactersSquareBrackets);
+
+          if(trimTailwindWhitespace(after).length > 0){
+            return;
+          }
 
           const fixedClass = major >= TailwindcssVersion.V4
             ? buildClass({ ...dissectedClass, base: [...beforeSquareBrackets, `(${characters})`, ...afterSquareBrackets].join("") })
@@ -252,6 +256,10 @@ function extractBalanced(className: string, start = "(", end = ")") {
     before: before.join(""),
     characters: characters.join("")
   };
+}
+
+function trimTailwindWhitespace(className: string): string {
+  return className.replace(/^_+|_+$/g, "");
 }
 
 export function getOptions(ctx: Rule.RuleContext) {


### PR DESCRIPTION
Fixes false positives when using multiple vars in arbitrary values:

```html
<img class="object-[var(--x)_var(--y)]" />
```