### PR TITLE
fix: matching object values with immediate indexed access

### DIFF
--- a/src/parsers/jsx.test.ts
+++ b/src/parsers/jsx.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
+import { MatcherType } from "better-tailwindcss:types/rule.js";
 
 
 describe("jsx", () => {
@@ -20,6 +21,7 @@ describe("jsx", () => {
     });
   });
 
+  // #119
   it("should not report inside member expressions", () => {
     lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
@@ -29,6 +31,24 @@ describe("jsx", () => {
       ]
     });
   });
+
+  // #211
+  it("should still handle object values even when they are immediately index accessed", () => {
+    lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+      invalid: [
+        {
+          jsx: "<img class={{ key: '  a b c  '}['key']} />",
+          jsxOutput: "<img class={{ key: 'a b c'}['key']} />",
+
+          errors: 2,
+          options: [{
+            attributes: [["class", [{ match: MatcherType.ObjectValue }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 });
 
 describe("astro (jsx)", () => {

--- a/src/parsers/svelte.test.ts
+++ b/src/parsers/svelte.test.ts
@@ -5,6 +5,7 @@ import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
+import { MatcherType } from "better-tailwindcss:types/rule.js";
 
 
 describe("svelte", () => {
@@ -58,6 +59,7 @@ describe("svelte", () => {
     });
   });
 
+  // #119
   it("should not report inside member expressions", () => {
     lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
       valid: [
@@ -67,5 +69,23 @@ describe("svelte", () => {
       ]
     });
   });
+
+  // #211
+  it("should still handle object values even when they are immediately index accessed", () => {
+    lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+      invalid: [
+        {
+          svelte: "<img class={{ key: '  a b c  '}['key']} />",
+          svelteOutput: "<img class={{ key: 'a b c'}['key']} />",
+
+          errors: 2,
+          options: [{
+            attributes: [["class", [{ match: MatcherType.ObjectValue }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 
 });

--- a/src/parsers/vue.test.ts
+++ b/src/parsers/vue.test.ts
@@ -154,4 +154,21 @@ describe("vue", () => {
     });
   });
 
+  // #211
+  it("should still handle object values even when they are immediately index accessed", () => {
+    lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+      invalid: [
+        {
+          vue: `<template><img :class="{ key: '  a b c  ' }['key']" /></template>`,
+          vueOutput: `<template><img :class="{ key: 'a b c' }['key']" /></template>`,
+
+          errors: 2,
+          options: [{
+            attributes: [[".*", [{ match: MatcherType.ObjectValue }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 });

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -155,6 +155,6 @@ export function isInsideLogicalExpressionLeft(node: ESNode & Partial<Rule.NodePa
 export function isInsideMemberExpression(node: ESNode & Partial<Rule.NodeParentExtension>): boolean {
   // aka indexed access: https://github.com/estree/estree/blob/master/es5.md#memberexpression
   if(!hasESNodeParentExtension(node)){ return false; }
-  if(node.parent.type === "MemberExpression"){ return true; }
+  if(node.parent.type === "MemberExpression" && node.parent.property === node){ return true; }
   return isInsideMemberExpression(node.parent);
 }


### PR DESCRIPTION
fixes: #211 

```jsx
<img class={{ key: 'will now be fixed'}['key']} />
```