### PR TITLE
fix: don't match indexed accessed object keys

### DIFF
--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -587,7 +587,6 @@ function getESMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESNode> {
 
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node) ||
             isESObjectKey(node) ||
 
             !isESStringLike(node)){

--- a/src/parsers/jsx.test.ts
+++ b/src/parsers/jsx.test.ts
@@ -49,6 +49,21 @@ describe("jsx", () => {
     });
   });
 
+  // #226
+  it("should not match index accessed object keys", () => {
+    lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+      valid: [
+        {
+          jsx: "<img class={{ '  a b c  ': '  d e f '}['  a b c  ']} />",
+
+          options: [{
+            attributes: [["class", [{ match: MatcherType.ObjectKey }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 });
 
 describe("astro (jsx)", () => {

--- a/src/parsers/svelte.test.ts
+++ b/src/parsers/svelte.test.ts
@@ -87,5 +87,19 @@ describe("svelte", () => {
     });
   });
 
+  // #226
+  it("should not match index accessed object keys", () => {
+    lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+      valid: [
+        {
+          svelte: "<img class={{ '  a b c  ': '  d e f '}['  a b c  ']} />",
+
+          options: [{
+            attributes: [["class", [{ match: MatcherType.ObjectKey }]]]
+          }]
+        }
+      ]
+    });
+  });
 
 });

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -259,7 +259,6 @@ function getSvelteMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBase
 
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node) ||
             isESObjectKey(node) ||
 
             !isESStringLike(node) && !isSvelteStringLiteral(node)){

--- a/src/parsers/vue.test.ts
+++ b/src/parsers/vue.test.ts
@@ -171,4 +171,19 @@ describe("vue", () => {
     });
   });
 
+  // #226
+  it("should not match index accessed object keys", () => {
+    lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+      valid: [
+        {
+          vue: "<template><img class={{ '  a b c  ': '  d e f '}['  a b c  ']} /></template>",
+
+          options: [{
+            attributes: [["class", [{ match: MatcherType.ObjectKey }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 });

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -238,7 +238,6 @@ function getVueMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBaseNod
 
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node) ||
             isESObjectKey(node) ||
 
             !isESStringLike(node) && !isVueLiteralNode(node)){

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -155,6 +155,6 @@ export function isInsideLogicalExpressionLeft(node: ESNode & Partial<Rule.NodePa
 export function isInsideMemberExpression(node: ESNode & Partial<Rule.NodeParentExtension>): boolean {
   // aka indexed access: https://github.com/estree/estree/blob/master/es5.md#memberexpression
   if(!hasESNodeParentExtension(node)){ return false; }
-  if(node.parent.type === "MemberExpression" && node.parent.property === node){ return true; }
+  if(node.parent.type === "MemberExpression"){ return true; }
   return isInsideMemberExpression(node.parent);
 }


### PR DESCRIPTION
fixes: #226 

```ts
const someVariableWithObjectKeysMatcher = { "shouldNotBeDetected": "border-solid" }[someVariable]
```
