### PR TITLE
chore: correct recommended rules to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | Name | Description | `tw3` | `tw4` | `recommended` | autofix |
 | :--- | :--- | :---: | :---: | :---: | :---: |
 | [no-unregistered-classes](docs/rules/no-unregistered-classes.md) | Report classes not registered with tailwindcss. | ✔ | ✔ | ✔ |  |
-| [no-conflicting-classes](docs/rules/no-conflicting-classes.md) | Report classes that produce conflicting styles. |  | ✔ |  |  |
+| [no-conflicting-classes](docs/rules/no-conflicting-classes.md) | Report classes that produce conflicting styles. |  | ✔ | ✔ |  |
 | [no-restricted-classes](docs/rules/no-restricted-classes.md) | Disallow restricted classes. | ✔ | ✔ |  | ✔ |
 
 <br/>

--- a/src/rules/no-conflicting-classes.ts
+++ b/src/rules/no-conflicting-classes.ts
@@ -62,7 +62,7 @@ export const noConflictingClasses: ESLintRule<Options> = {
     meta: {
       docs: {
         description: "Disallow classes that produce conflicting styles.",
-        recommended: false,
+        recommended: true,
         url: DOCUMENTATION_URL
       },
       fixable: "code",

--- a/src/rules/no-unregistered-classes.ts
+++ b/src/rules/no-unregistered-classes.ts
@@ -70,7 +70,7 @@ export const noUnregisteredClasses: ESLintRule<Options> = {
     meta: {
       docs: {
         description: "Disallow any css classes that are not registered in tailwindcss.",
-        recommended: false,
+        recommended: true,
         url: DOCUMENTATION_URL
       },
       fixable: "code",


### PR DESCRIPTION
**Thank you for the great ESLint rules!**

I have updated README to match the implementation.

While using this rules in practice, I noticed this diff.
After checking [the code](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/56aa614b8264b6ce2814c0b99252e55b58b5520a/src/configs/config.ts#L54), I confirmed that the `no-conflicting-classes` rule is indeed listed in the `recommended`.