### PR TITLE
Add more `rounded` rules to `enforce-shorthand-classes`

### DIFF
--- a/src/rules/enforce-shorthand-classes.ts
+++ b/src/rules/enforce-shorthand-classes.ts
@@ -121,6 +121,8 @@ export const shorthands = [
   ],
   [
     [[/^rounded-tl-(.*)$/, /^rounded-tr-(.*)$/, /^rounded-bl-(.*)$/, /^rounded-br-(.*)$/], ["rounded-$1"]],
+    [[/^rounded-t-(.*)$/, /^rounded-b-(.*)$/], ["rounded-$1"]],
+    [[/^rounded-l-(.*)$/, /^rounded-r-(.*)$/], ["rounded-$1"]],
     [[/^rounded-tl-(.*)$/, /^rounded-tr-(.*)$/], ["rounded-t-$1"]],
     [[/^rounded-bl-(.*)$/, /^rounded-br-(.*)$/], ["rounded-b-$1"]],
     [[/^rounded-tl-(.*)$/, /^rounded-bl-(.*)$/], ["rounded-l-$1"]],


### PR DESCRIPTION
Hi,

Just ran into this and decided to contribute :)

`rounded-l-none rounded-r-none` → `rounded-none`
`rounded-t-none rounded-b-none` → `rounded-none`

Thank you for the great work on `eslint-plugin-better-tailwindcss`!

Have a good day,
Andrew