### PR TITLE
fix: convert missing flex shrink and grow utilities

### DIFF
--- a/docs/rules/no-deprecated-classes.md
+++ b/docs/rules/no-deprecated-classes.md
@@ -14,7 +14,9 @@ The following classes will be reported as deprecated:
 | `divide-opacity-*`        | Use opacity modifiers like `divide-black/50`  |
 | `ring-opacity-*`          | Use opacity modifiers like `ring-black/50`    |
 | `placeholder-opacity-*`   | Use opacity modifiers like `placeholder-black/50` |
+| `flex-shrink`             | `shrink`                                      |
 | `flex-shrink-*`           | `shrink-*`                                    |
+| `flex-grow`               | `grow`                                        |
 | `flex-grow-*`             | `grow-*`                                      |
 | `overflow-ellipsis`       | `text-ellipsis`                               |
 | `decoration-slice`        | `box-decoration-slice`                        |

--- a/src/rules/no-deprecated-classes.test.ts
+++ b/src/rules/no-deprecated-classes.test.ts
@@ -21,7 +21,9 @@ const testCases = [
   ["ring-opacity-70", undefined],
   ["placeholder-opacity-70", undefined],
 
+  ["flex-shrink", "shrink"],
   ["flex-shrink-1", "shrink-1"],
+  ["flex-grow", "grow"],
   ["flex-grow-1", "grow-1"],
 
   ["overflow-ellipsis", "text-ellipsis"],

--- a/src/rules/no-deprecated-classes.ts
+++ b/src/rules/no-deprecated-classes.ts
@@ -105,7 +105,9 @@ const deprecations = [
       [/^ring-opacity-(.*)$/],
       [/^placeholder-opacity-(.*)$/],
 
+      [/^flex-shrink$/, "shrink"],
       [/^flex-shrink-(.*)$/, "shrink-$1"],
+      [/^flex-grow$/, "grow"],
       [/^flex-grow-(.*)$/, "grow-$1"],
 
       [/^overflow-ellipsis$/, "text-ellipsis"],


### PR DESCRIPTION
## Summary
Thank you so much for maintaining eslint-plugin-better-tailwindcss — we rely on it every day!
The `no-deprecated-classes` rule already rewrites `flex-grow-*` / `flex-shrink-*` to the modern `grow-*` / `shrink-*`, but plain `flex-grow` / `flex-shrink`
were still slipping through. This PR adds the missing fixer so those base utilities are also replaced with `grow` / `shrink`.

## Context
- The public upgrade guide (https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities) doesn’t mention `flex-grow` / `flex-shrink`, which
makes their deprecation easy to miss.
- However, the official @tailwindcss/upgrade codemod explicitly migrates `flex-grow` → `grow` and `flex-shrink` → `shrink` (see https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-upgrade/src/codemods/template/migrate-simple-legacy-classes.ts#L10-L13 ).
- To keep this plugin aligned with the codemod, plain `flex-grow` / `flex-shrink` are now rewritten to `grow` / `shrink`, and the docs plus snapshot tests
have been updated accordingly.

