### PR TITLE
fix: wrong documentation url

### DIFF
--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -70,7 +70,7 @@ const defaultOptions = {
   variables: DEFAULT_VARIABLE_NAMES
 } as const satisfies Options[0];
 
-const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/multiline.md";
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-consistent-line-wrapping.md";
 
 export const enforceConsistentLineWrapping: ESLintRule<Options> = {
   name: "enforce-consistent-line-wrapping" as const,


### PR DESCRIPTION
### Description

Current documentation url leads to `404 - page not found`

### Fix

Changed the url from `https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/multiline.md` to `https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-consistent-line-wrapping.md`