### PR TITLE
docs: add attribute matcher example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can match custom attributes by modifying your `attributes` matcher configura
 
 <br/>
 
-```jsonc
+```mjs
 // eslint.config.mjs
 import bettertailwindcss from "eslint-plugin-better-tailwindcss";
 


### PR DESCRIPTION
It would be nice to add concrete examples with an example config to explain how to configure the linter.

This is one example for [Algolia custom css classes](https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/react#pass-ustom-css-classes-to-widgets).

I think it would be useful to add such examples for ShadCN, React Aria and other popular libraries.

If there is default support for those it would be nice to address that and explain what the default matchers will match out of the box.