### PR TITLE
refactor: update rule recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | [enforce-consistent-variable-syntax](docs/rules/enforce-consistent-variable-syntax.md) | Enforce consistent variable syntax. | ✔ | ✔ |  | ✔ |
 | [enforce-consistent-important-position](docs/rules/enforce-consistent-important-position.md) | Enforce consistent position of the important modifier. | ✔ | ✔ |  | ✔ |
 | [enforce-shorthand-classes](docs/rules/enforce-shorthand-classes.md) | Enforce shorthand class names. | ✔ | ✔ |  | ✔ |
-| [enforce-canonical-classes](docs/rules/enforce-canonical-classes.md) | Enforce canonical class names. |  | ✔ |  | ✔ |
+| [enforce-canonical-classes](docs/rules/enforce-canonical-classes.md) | Enforce canonical class names. |  | ✔ | ✔ | ✔ |
 | [no-duplicate-classes](docs/rules/no-duplicate-classes.md) | Remove duplicate classes. | ✔ | ✔ | ✔ | ✔ |
-| [no-deprecated-classes](docs/rules/no-deprecated-classes.md) | Remove deprecated classes. |  | ✔ |  | ✔ |
+| [no-deprecated-classes](docs/rules/no-deprecated-classes.md) | Remove deprecated classes. |  | ✔ | ✔ | ✔ |
 | [no-unnecessary-whitespace](docs/rules/no-unnecessary-whitespace.md) | Disallow unnecessary whitespace in tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 
 #### Correctness rules

--- a/src/rules/enforce-canonical-classes.ts
+++ b/src/rules/enforce-canonical-classes.ts
@@ -14,7 +14,7 @@ export const enforceCanonicalClasses = createRule({
   description: "Enforce canonical class names.",
   docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-canonical-classes.md",
   name: "enforce-canonical-classes",
-  recommended: false,
+  recommended: true,
 
   messages: {
     canonical: "The class: \"{{ className }}\" can be simplified to \"{{canonicalClass}}\"."

--- a/src/rules/enforce-shorthand-classes.ts
+++ b/src/rules/enforce-shorthand-classes.ts
@@ -17,7 +17,7 @@ export const enforceShorthandClasses = createRule({
   description: "Enforce shorthand class names instead of longhand class names.",
   docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-shorthand-classes.md",
   name: "enforce-shorthand-classes",
-  recommended: true,
+  recommended: false,
 
   messages: {
     longhand: "Non shorthand class detected. Expected {{ longhands }} to be {{ shorthands }}",

--- a/src/rules/no-conflicting-classes.ts
+++ b/src/rules/no-conflicting-classes.ts
@@ -17,7 +17,7 @@ export const noConflictingClasses = createRule({
   description: "Disallow classes that produce conflicting styles.",
   docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/no-conflicting-classes.md",
   name: "no-conflicting-classes",
-  recommended: false,
+  recommended: true,
 
   messages: {
     conflicting: "Conflicting class detected: \"{{ className }}\" and \"{{ conflictingClassString }}\" apply the same CSS properties: \"{{ conflictingPropertiesString }}\"."

--- a/src/rules/no-deprecated-classes.ts
+++ b/src/rules/no-deprecated-classes.ts
@@ -15,7 +15,7 @@ export const noDeprecatedClasses = createRule({
   description: "Disallow the use of deprecated Tailwind CSS classes.",
   docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/no-deprecated-classes.md",
   name: "no-deprecated-classes",
-  recommended: false,
+  recommended: true,
 
   messages: {
     irreplaceable: "Class \"{{ className }}\" is deprecated. Check the tailwindcss documentation for more information: https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities",

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -30,7 +30,7 @@ export const noUnknownClasses = createRule({
   description: "Disallow any css classes that are not registered in tailwindcss.",
   docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/no-unknown-classes.md",
   name: "no-unknown-classes",
-  recommended: false,
+  recommended: true,
 
   messages: {
     unknown: "Unknown class detected: {{ className }}"


### PR DESCRIPTION
Update recommended rules: 

- `enforce-canonical-classes` is now recommended.
- `no-conflicting-classes` is now recommended.
- `no-deprecated-classes` is now recommended.
- `no-unknown-classes` is now recommended.
- `enforce-shorthand-classes` is no longer recommended due to conflicts of `enforce-canonical-classes`.
