### PR TITLE
refactor: deprecate api path for imports

### DIFF
--- a/docs/api/defaults.md
+++ b/docs/api/defaults.md
@@ -2,7 +2,7 @@
 # Defaults
 
 The plugin comes with a set of default [matchers](../configuration/advanced.md#matchers) for `attributes`, `callees`, `variables` and `tags`. These matchers are used to [determine how the rules should behave](../configuration/advanced.md#advanced-configuration) when checking your code.
-In order to extend the default configuration instead of overwriting it, you can import the default options from `eslint-plugin-better-tailwindcss/api/defaults` and merge them with your own options.
+In order to extend the default configuration instead of overwriting it, you can import the default options from `eslint-plugin-better-tailwindcss/defaults` and merge them with your own options.
 
 <br/>
 <br/>
@@ -16,8 +16,8 @@ import {
   getDefaultCallees,
   getDefaultTags,
   getDefaultVariables
-} from "eslint-plugin-better-tailwindcss/api/defaults";
-import { MatcherType } from "eslint-plugin-better-tailwindcss/api/types";
+} from "eslint-plugin-better-tailwindcss/defaults";
+import { MatcherType } from "eslint-plugin-better-tailwindcss/types";
 
 
 export default [

--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -6,9 +6,9 @@ By default, the plugin is configured to work with [most popular tailwind utiliti
 
 It is possible to override the default configuration by defining the [`callees`](../settings/settings.md#callees), [`attributes`](../settings/settings.md#attributes), [`tags`](../settings/settings.md#tags) and [`variables`](../settings/settings.md#variables) option for each rule individually, or globally via the [settings](../settings/settings.md) object in ESLint.
 
-In order to extend the default configuration instead of overriding it, you can import the default options from `eslint-plugin-better-tailwindcss/api/defaults` and merge them with your own config.
+In order to extend the default configuration instead of overriding it, you can import the default options from `eslint-plugin-better-tailwindcss/defaults` and merge them with your own config.
 
-You can read more about the default configuration in the [defaults documentation](../api/defaults.md).
+You can read more about the default configuration in the [defaults documentation](../defaults.md).
 
 <br/>
 <br/>
@@ -233,7 +233,7 @@ You can match custom attributes by modifying your `attributes` matcher configura
 ```js
 // eslint.config.js
 import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss";
-import { getDefaultAttributes } from "eslint-plugin-better-tailwindcss/api/defaults";
+import { getDefaultAttributes } from "eslint-plugin-better-tailwindcss/defaults";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "exports": {
     ".": "./lib/configs/config.js",
     "./api/defaults": "./lib/api/defaults.js",
-    "./api/types": "./lib/api/types.js"
+    "./api/types": "./lib/api/types.js",
+    "./defaults": "./lib/api/defaults.js",
+    "./types": "./lib/api/types.js"
   },
   "main": "./lib/configs/config.js",
   "scripts": {


### PR DESCRIPTION
Remove `api` subdirectory from imports:

```diff
- import { getDefaultAttributes } from "eslint-plugin-better-tailwindcss/api/defaults";
+ import { getDefaultAttributes } from "eslint-plugin-better-tailwindcss/defaults";
```

The old path with `/api` is still available for backwards compatibility.
