### PR TITLE
feat: oxlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <br/>
 <br/>
 
-ESLint plugin with formatting and linting rules to help you write cleaner, more maintainable Tailwind CSS.  
+ESLint/Oxlint plugin with formatting and linting rules to help you write cleaner, more maintainable Tailwind CSS.  
 
 The formatting rules focus on improving readability by automatically breaking up long Tailwind class strings into multiple lines and sorting/grouping them in a logical order. The linting rules enforce best practices and catch potential issues, ensuring that you're writing valid Tailwind CSS.  
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,16 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "oxlint": "^1.35.0",
         "tailwindcss": "^3.3.0 || ^4.1.17"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "oxlint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,16 @@
   ],
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+    "oxlint": "^1.35.0",
     "tailwindcss": "^3.3.0 || ^4.1.17"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    },
+    "oxlint": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@eslint/css-tree": "^3.6.8",


### PR DESCRIPTION
Enables plugin to be used with [oxlint](https://oxc.rs) without ESLint.

Does not yet implement the `createOnce` method as it requires a refactoring of the options and settings handling. This can be added later.