### PR TITLE
fix: angular bound attribute name values

### DIFF
--- a/src/parsers/angular.ts
+++ b/src/parsers/angular.ts
@@ -139,7 +139,9 @@ function createLiteralsByAngularAttribute(ctx: Rule.RuleContext, attribute: Tmpl
 
 function getLiteralsByAngularMatchers(ctx: Rule.RuleContext, ast: AST | TmplAstBoundAttribute, matchers: Matcher[]): Literal[] {
   const matcherFunctions = getAngularMatcherFunctions(ctx, matchers);
-  const matchingAstNodes = getLiteralNodesByMatchers(ctx, ast, matcherFunctions, value => isAST(value) && isCallExpression(value));
+  const matchingAstNodes = getLiteralNodesByMatchers(ctx, ast, matcherFunctions, value => {
+    return isAST(value) && isCallExpression(value) || isBoundAttributeName(ast);
+  });
   const literals = matchingAstNodes.flatMap(ast => createLiteralsByAngularAst(ctx, ast));
 
   return literals.filter(deduplicateLiterals);


### PR DESCRIPTION
Prevents matching strings in attribute values when the attribute is a bound attribute name:

```html
  <img [class.badge-info]="banner.theme === 'Info'" />
```

fixes: #274