### PR TITLE
fix!: ignore indexed access keys

### DIFF
--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -4,6 +4,7 @@ import {
   getLiteralNodesByMatchers,
   isCalleeMatchers,
   isCalleeName,
+  isIndexedAccessLiteral,
   isInsideBinaryExpression,
   isInsideConditionalExpressionTest,
   isInsideLogicalExpressionLeft,
@@ -509,7 +510,7 @@ function getESMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESNode> {
             isInsideBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node) ||
+            isIndexedAccessLiteral(node) ||
 
             isESObjectKey(node) ||
             isInsideObjectValue(node)){
@@ -531,7 +532,8 @@ function getESMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESNode> {
             isInsideBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node)){
+            isInsideMemberExpression(node) ||
+            isIndexedAccessLiteral(node)){
             return false;
           }
 
@@ -557,6 +559,7 @@ function getESMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESNode> {
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isESObjectKey(node) ||
+            isIndexedAccessLiteral(node) ||
 
             !isESStringLike(node)){
             return false;

--- a/src/parsers/jsx.test.ts
+++ b/src/parsers/jsx.test.ts
@@ -64,6 +64,34 @@ describe("jsx", () => {
     });
   });
 
+  // #286
+  it("should not match index access string literals", () => {
+    lint(noUnnecessaryWhitespace, {
+      invalid: [
+        {
+          jsx: "<img class={{ ' a b c ': ' d e f '}[' a b c ']} />",
+          jsxOutput: "<img class={{ ' a b c ': 'd e f'}[' a b c ']} />",
+
+          errors: 2,
+
+          options: [{
+            attributes: [["class", [{ match: MatcherType.ObjectValue }]]]
+          }]
+        },
+        {
+          jsx: "<img class={cx(' a b c ')[' d e f ']} />",
+          jsxOutput: "<img class={cx('a b c')[' d e f ']} />",
+
+          errors: 2,
+
+          options: [{
+            callees: [["cx", [{ match: MatcherType.String }]]]
+          }]
+        }
+      ]
+    });
+  });
+
 });
 
 describe("astro (jsx)", () => {

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -13,6 +13,7 @@ import {
   getLiteralNodesByMatchers,
   isAttributesMatchers,
   isAttributesName,
+  isIndexedAccessLiteral,
   isInsideBinaryExpression,
   isInsideConditionalExpressionTest,
   isInsideLogicalExpressionLeft,
@@ -322,7 +323,7 @@ function getSvelteMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBase
             isInsideBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node) ||
+            isIndexedAccessLiteral(node) ||
 
             isESObjectKey(node) ||
             isInsideObjectValue(node)){
@@ -345,7 +346,8 @@ function getSvelteMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBase
             isInsideBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node)){
+            isInsideMemberExpression(node) ||
+            isIndexedAccessLiteral(node)){
             return false;
           }
 
@@ -371,6 +373,7 @@ function getSvelteMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBase
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isESObjectKey(node) ||
+            isIndexedAccessLiteral(node) ||
 
             !isESStringLike(node) && !isSvelteStringLiteral(node)){
             return false;

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -14,6 +14,7 @@ import {
   getLiteralNodesByMatchers,
   isAttributesMatchers,
   isAttributesName,
+  isIndexedAccessLiteral,
   isInsideBinaryExpression,
   isInsideConditionalExpressionTest,
   isInsideLogicalExpressionLeft,
@@ -197,7 +198,7 @@ function getVueMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBaseNod
             isInsideBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node) ||
+            isIndexedAccessLiteral(node) ||
 
             isESObjectKey(node) ||
             isInsideObjectValue(node)){
@@ -219,7 +220,8 @@ function getVueMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBaseNod
             isInsideBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
-            isInsideMemberExpression(node)){
+            isInsideMemberExpression(node) ||
+            isIndexedAccessLiteral(node)){
             return false;
           }
 
@@ -245,6 +247,7 @@ function getVueMatcherFunctions(matchers: Matcher[]): MatcherFunctions<ESBaseNod
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isESObjectKey(node) ||
+            isIndexedAccessLiteral(node) ||
 
             !isESStringLike(node) && !isVueLiteralNode(node)){
             return false;

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -3,6 +3,7 @@ import {
   isESArrowFunctionExpression,
   isESCallExpression,
   isESNode,
+  isESSimpleStringLiteral,
   isESVariableDeclarator
 } from "better-tailwindcss:parsers/es.js";
 import { isGenericNodeWithParent } from "better-tailwindcss:utils/utils.js";
@@ -134,4 +135,10 @@ export function isInsideMemberExpression(node: WithParent<ESNode>): boolean {
   if(!hasESNodeParentExtension(node)){ return false; }
   if(node.parent.type === "MemberExpression"){ return true; }
   return isInsideMemberExpression(node.parent);
+}
+
+export function isIndexedAccessLiteral(node: WithParent<ESNode>): boolean {
+  if(!hasESNodeParentExtension(node)){ return false; }
+  if(node.parent.type !== "MemberExpression"){ return false; }
+  return node.parent.property === node && isESSimpleStringLiteral(node);
 }


### PR DESCRIPTION
Now ignores indexed access keys in matchers:

```tsx
<img class={{ 'a b c': 'd e f'}['g h i']} />
//                              ^^^^^^^ is now ignored
```

fixes: #286