### PR TITLE
fix: disallow extra properties in rule options (valibot schemas)

### DIFF
--- a/src/options/descriptions.ts
+++ b/src/options/descriptions.ts
@@ -1,4 +1,4 @@
-import { object } from "valibot";
+import { strictObject } from "valibot";
 
 import { ATTRIBUTES_OPTION_SCHEMA } from "better-tailwindcss:options/schemas/attributes.js";
 import { CALLEES_OPTION_SCHEMA } from "better-tailwindcss:options/schemas/callees.js";
@@ -16,7 +16,7 @@ import { VARIABLES_OPTION_SCHEMA } from "better-tailwindcss:options/schemas/vari
 import type { InferOutput } from "valibot";
 
 
-export const COMMON_OPTIONS = object({
+export const COMMON_OPTIONS = strictObject({
   ...CALLEES_OPTION_SCHEMA.entries,
   ...ATTRIBUTES_OPTION_SCHEMA.entries,
   ...VARIABLES_OPTION_SCHEMA.entries,

--- a/src/options/schemas/attributes.ts
+++ b/src/options/schemas/attributes.ts
@@ -1,9 +1,9 @@
 import {
   array,
   description,
-  object,
   optional,
   pipe,
+  strictObject,
   string,
   tuple,
   union
@@ -16,7 +16,6 @@ import {
   STRING_MATCHER_SCHEMA
 } from "better-tailwindcss:options/schemas/matchers.js";
 
-import type { Rule } from "eslint";
 import type { InferOutput } from "valibot";
 
 
@@ -61,8 +60,8 @@ export const ATTRIBUTES_SCHEMA = pipe(
 
 export type Attributes = InferOutput<typeof ATTRIBUTES_SCHEMA>;
 
-export const ATTRIBUTES_OPTION_SCHEMA = object({
+export const ATTRIBUTES_OPTION_SCHEMA = strictObject({
   attributes: optional(ATTRIBUTES_SCHEMA, DEFAULT_ATTRIBUTE_NAMES)
-}) satisfies Rule.RuleMetaData["schema"];
+});
 
 export type AttributesOptions = InferOutput<typeof ATTRIBUTES_OPTION_SCHEMA>;

--- a/src/options/schemas/callees.ts
+++ b/src/options/schemas/callees.ts
@@ -1,9 +1,9 @@
 import {
   array,
   description,
-  object,
   optional,
   pipe,
+  strictObject,
   string,
   tuple,
   union
@@ -16,7 +16,6 @@ import {
   STRING_MATCHER_SCHEMA
 } from "better-tailwindcss:options/schemas/matchers.js";
 
-import type { Rule } from "eslint";
 import type { InferOutput } from "valibot";
 
 
@@ -61,8 +60,8 @@ export const CALLEES_SCHEMA = pipe(
 
 export type Callees = InferOutput<typeof CALLEES_SCHEMA>;
 
-export const CALLEES_OPTION_SCHEMA = object({
+export const CALLEES_OPTION_SCHEMA = strictObject({
   callees: optional(CALLEES_SCHEMA, DEFAULT_CALLEE_NAMES)
-}) satisfies Rule.RuleMetaData["schema"];
+});
 
 export type CalleesOptions = InferOutput<typeof CALLEES_OPTION_SCHEMA>;

--- a/src/options/schemas/common.ts
+++ b/src/options/schemas/common.ts
@@ -5,9 +5,9 @@ import {
   description,
   literal,
   number,
-  object,
   optional,
   pipe,
+  strictObject,
   string,
   union
 } from "valibot";
@@ -15,7 +15,7 @@ import {
 import type { InferOutput } from "valibot";
 
 
-export const ENTRYPOINT_OPTION_SCHEMA = object({
+export const ENTRYPOINT_OPTION_SCHEMA = strictObject({
   entryPoint: optional(
     pipe(
       string(),
@@ -27,7 +27,7 @@ export const ENTRYPOINT_OPTION_SCHEMA = object({
 
 export type EntryPointOption = InferOutput<typeof ENTRYPOINT_OPTION_SCHEMA>;
 
-export const TAILWIND_OPTION_SCHEMA = object({
+export const TAILWIND_OPTION_SCHEMA = strictObject({
   tailwindConfig: optional(
     pipe(
       string(),
@@ -39,7 +39,7 @@ export const TAILWIND_OPTION_SCHEMA = object({
 
 export type TailwindConfigOption = InferOutput<typeof TAILWIND_OPTION_SCHEMA>;
 
-export const TSCONFIG_OPTION_SCHEMA = object({
+export const TSCONFIG_OPTION_SCHEMA = strictObject({
   tsconfig: optional(
     pipe(
       string(),
@@ -51,7 +51,7 @@ export const TSCONFIG_OPTION_SCHEMA = object({
 
 export type TSConfigOption = InferOutput<typeof TSCONFIG_OPTION_SCHEMA>;
 
-export const MESSAGE_STYLE_OPTION_SCHEMA = object({
+export const MESSAGE_STYLE_OPTION_SCHEMA = strictObject({
   messageStyle: optional(
     pipe(
       union([
@@ -69,7 +69,7 @@ export const MESSAGE_STYLE_OPTION_SCHEMA = object({
 
 export type MessageStyleOption = InferOutput<typeof MESSAGE_STYLE_OPTION_SCHEMA>;
 
-export const DETECT_COMPONENT_CLASSES_OPTION_SCHEMA = object({
+export const DETECT_COMPONENT_CLASSES_OPTION_SCHEMA = strictObject({
   detectComponentClasses: optional(
     pipe(
       boolean(),
@@ -81,7 +81,7 @@ export const DETECT_COMPONENT_CLASSES_OPTION_SCHEMA = object({
 
 export type DetectComponentClassesOption = InferOutput<typeof DETECT_COMPONENT_CLASSES_OPTION_SCHEMA>;
 
-export const ROOT_FONT_SIZE_OPTION_SCHEMA = object({
+export const ROOT_FONT_SIZE_OPTION_SCHEMA = strictObject({
   rootFontSize: optional(
     pipe(
       number(),

--- a/src/options/schemas/matchers.ts
+++ b/src/options/schemas/matchers.ts
@@ -1,18 +1,16 @@
-import { description, literal, object, optional, pipe, string } from "valibot";
+import { description, literal, optional, pipe, strictObject, string } from "valibot";
 
 import { MatcherType } from "better-tailwindcss:types/rule.js";
 
-import type { Rule } from "eslint";
 
-
-export const STRING_MATCHER_SCHEMA = object({
+export const STRING_MATCHER_SCHEMA = strictObject({
   match: pipe(
     literal(MatcherType.String),
     description("Matcher type that will be applied.")
   )
-}) satisfies Rule.RuleMetaData["schema"];
+});
 
-export const OBJECT_KEY_MATCHER_SCHEMA = object({
+export const OBJECT_KEY_MATCHER_SCHEMA = strictObject({
   match: pipe(
     literal(MatcherType.ObjectKey),
     description("Matcher type that will be applied.")
@@ -21,9 +19,9 @@ export const OBJECT_KEY_MATCHER_SCHEMA = object({
     string(),
     description("Regular expression that filters the object key and matches the content for further processing in a group.")
   ))
-}) satisfies Rule.RuleMetaData["schema"];
+});
 
-export const OBJECT_VALUE_MATCHER_SCHEMA = object({
+export const OBJECT_VALUE_MATCHER_SCHEMA = strictObject({
   match: pipe(
     literal(MatcherType.ObjectValue),
     description("Matcher type that will be applied.")
@@ -32,4 +30,4 @@ export const OBJECT_VALUE_MATCHER_SCHEMA = object({
     string(),
     description("Regular expression that filters the object value and matches the content for further processing in a group.")
   ))
-}) satisfies Rule.RuleMetaData["schema"];
+});

--- a/src/options/schemas/tags.ts
+++ b/src/options/schemas/tags.ts
@@ -1,9 +1,9 @@
 import {
   array,
   description,
-  object,
   optional,
   pipe,
+  strictObject,
   string,
   tuple,
   union
@@ -16,7 +16,6 @@ import {
   STRING_MATCHER_SCHEMA
 } from "better-tailwindcss:options/schemas/matchers.js";
 
-import type { Rule } from "eslint";
 import type { InferOutput } from "valibot";
 
 
@@ -61,8 +60,8 @@ export const TAGS_SCHEMA = pipe(
 
 export type Tags = InferOutput<typeof TAGS_SCHEMA>;
 
-export const TAGS_OPTIONS_SCHEMA = object({
+export const TAGS_OPTIONS_SCHEMA = strictObject({
   tags: optional(TAGS_SCHEMA, DEFAULT_TAG_NAMES)
-}) satisfies Rule.RuleMetaData["schema"];
+});
 
 export type TagsOptions = InferOutput<typeof TAGS_OPTIONS_SCHEMA>;

--- a/src/options/schemas/variables.ts
+++ b/src/options/schemas/variables.ts
@@ -1,9 +1,9 @@
 import {
   array,
   description,
-  object,
   optional,
   pipe,
+  strictObject,
   string,
   tuple,
   union
@@ -16,7 +16,6 @@ import {
   STRING_MATCHER_SCHEMA
 } from "better-tailwindcss:options/schemas/matchers.js";
 
-import type { Rule } from "eslint";
 import type { InferOutput } from "valibot";
 
 
@@ -61,8 +60,8 @@ export const VARIABLES_SCHEMA = pipe(
 
 export type Variables = InferOutput<typeof VARIABLES_SCHEMA>;
 
-export const VARIABLES_OPTION_SCHEMA = object({
+export const VARIABLES_OPTION_SCHEMA = strictObject({
   variables: optional(VARIABLES_SCHEMA, DEFAULT_VARIABLE_NAMES)
-}) satisfies Rule.RuleMetaData["schema"];
+});
 
 export type VariablesOptions = InferOutput<typeof VARIABLES_OPTION_SCHEMA>;

--- a/src/rules/enforce-canonical-classes.ts
+++ b/src/rules/enforce-canonical-classes.ts
@@ -1,4 +1,4 @@
-import { boolean, description, object, optional, pipe } from "valibot";
+import { boolean, description, optional, pipe, strictObject } from "valibot";
 
 import { createGetCanonicalClasses, getCanonicalClasses } from "better-tailwindcss:tailwindcss/canonical-classes.js";
 import { async } from "better-tailwindcss:utils/context.js";
@@ -18,7 +18,7 @@ export const enforceCanonicalClasses = createRule({
   name: "enforce-canonical-classes",
   recommended: true,
 
-  schema: object({
+  schema: strictObject({
     collapse: optional(
       pipe(
         boolean(),

--- a/src/rules/enforce-consistent-class-order.ts
+++ b/src/rules/enforce-consistent-class-order.ts
@@ -1,4 +1,4 @@
-import { description, literal, object, optional, pipe, union } from "valibot";
+import { description, literal, optional, pipe, strictObject, union } from "valibot";
 
 import { createGetClassOrder, getClassOrder } from "better-tailwindcss:tailwindcss/class-order.js";
 import {
@@ -28,7 +28,7 @@ export const enforceConsistentClassOrder = createRule({
     order: "Incorrect class order. Expected\n\n{{ notSorted }}\n\nto be\n\n{{ sorted }}"
   },
 
-  schema: object({
+  schema: strictObject({
     componentClassOrder: optional(
       pipe(
         union([

--- a/src/rules/enforce-consistent-important-position.ts
+++ b/src/rules/enforce-consistent-important-position.ts
@@ -1,4 +1,4 @@
-import { description, literal, object, optional, pipe, union } from "valibot";
+import { description, literal, optional, pipe, strictObject, union } from "valibot";
 
 import { createGetDissectedClasses, getDissectedClasses } from "better-tailwindcss:tailwindcss/dissect-classes.js";
 import { buildClass } from "better-tailwindcss:utils/class.js";
@@ -20,7 +20,7 @@ export const enforceConsistentImportantPosition = createRule({
     position: "Incorrect important position. '{{ className }}' should be '{{ fix }}'."
   },
 
-  schema: object({
+  schema: strictObject({
     position: optional(
       pipe(
         union([

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -4,9 +4,9 @@ import {
   literal,
   minValue,
   number,
-  object,
   optional,
   pipe,
+  strictObject,
   union
 } from "valibot";
 
@@ -39,7 +39,7 @@ export const enforceConsistentLineWrapping = createRule({
     unnecessary: "Unnecessary line wrapping. Expected\n\n{{ notReadable }}\n\nto be\n\n{{ readable }}"
   },
 
-  schema: object({
+  schema: strictObject({
     classesPerLine: optional(
       pipe(
         number(),

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -1,4 +1,4 @@
-import { description, literal, object, optional, pipe, union } from "valibot";
+import { description, literal, optional, pipe, strictObject, union } from "valibot";
 
 import { createGetDissectedClasses, getDissectedClasses } from "better-tailwindcss:tailwindcss/dissect-classes.js";
 import { buildClass } from "better-tailwindcss:utils/class.js";
@@ -23,7 +23,7 @@ export const enforceConsistentVariableSyntax = createRule({
     incorrect: "Incorrect variable syntax: {{ className }}."
   },
 
-  schema: object({
+  schema: strictObject({
     syntax: optional(
       pipe(
         union([

--- a/src/rules/no-restricted-classes.ts
+++ b/src/rules/no-restricted-classes.ts
@@ -1,9 +1,9 @@
 import {
   array,
   description,
-  object,
   optional,
   pipe,
+  strictObject,
   string,
   union
 } from "valibot";
@@ -24,11 +24,11 @@ export const noRestrictedClasses = createRule({
   name: "no-restricted-classes",
   recommended: false,
 
-  schema: object({
+  schema: strictObject({
     restrict: optional(
       array(
         union([
-          object(
+          strictObject(
             {
               fix: optional(
                 pipe(

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -1,4 +1,4 @@
-import { array, description, object, optional, pipe, string } from "valibot";
+import { array, description, optional, pipe, strictObject, string } from "valibot";
 
 import {
   createGetCustomComponentClasses,
@@ -28,7 +28,7 @@ export const noUnknownClasses = createRule({
     unknown: "Unknown class detected: {{ className }}"
   },
 
-  schema: object({
+  schema: strictObject({
     ignore: optional(
       pipe(
         array(

--- a/src/rules/no-unnecessary-whitespace.ts
+++ b/src/rules/no-unnecessary-whitespace.ts
@@ -1,4 +1,4 @@
-import { boolean, description, object, optional, pipe } from "valibot";
+import { boolean, description, optional, pipe, strictObject } from "valibot";
 
 import { createRule } from "better-tailwindcss:utils/rule.js";
 import { splitClasses, splitWhitespaces } from "better-tailwindcss:utils/utils.js";
@@ -19,7 +19,7 @@ export const noUnnecessaryWhitespace = createRule({
     unnecessary: "Unnecessary whitespace."
   },
 
-  schema: object({
+  schema: strictObject({
     allowMultiline: optional(pipe(
       boolean(),
       description("Allow multi-line class declarations. If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [better-tailwindcss/enforce-consistent-line-wrapping](./enforce-consistent-line-wrapping.md).")

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,5 +1,5 @@
 import type { JSRuleDefinition } from "eslint";
-import type { BaseIssue, BaseSchema, Default, InferOutput, ObjectSchema, OptionalSchema } from "valibot";
+import type { BaseIssue, BaseSchema, Default, InferOutput, OptionalSchema, StrictObjectSchema } from "valibot";
 
 import type { CommonOptions } from "better-tailwindcss:options/descriptions.js";
 import type { Literal } from "better-tailwindcss:types/ast.js";
@@ -50,7 +50,7 @@ export type TSConfig = {
   tsconfig?: string;
 };
 
-export type Schema = ObjectSchema<Record<string, OptionalSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, Default<BaseSchema<unknown, unknown, BaseIssue<unknown>>, undefined>>>, undefined>;
+export type Schema = StrictObjectSchema<Record<string, OptionalSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, Default<BaseSchema<unknown, unknown, BaseIssue<unknown>>, undefined>>>, undefined>;
 export type JsonSchema<RawSchema extends Schema> = InferOutput<RawSchema>;
 
 export interface CreateRuleOptions<

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import { toJsonSchema } from "@valibot/to-json-schema";
-import { getDefaults, object } from "valibot";
+import { getDefaults, strictObject } from "valibot";
 
 import { COMMON_OPTIONS } from "better-tailwindcss:options/descriptions.js";
 import { getAttributesByAngularElement, getLiteralsByAngularAttribute } from "better-tailwindcss:parsers/angular.js";
@@ -57,7 +57,7 @@ export function createRule<
 
   let eslintContext: Rule.RuleContext | undefined;
 
-  const propertiesSchema = object({
+  const propertiesSchema = strictObject({
     // eslint injects the defaults from the settings to options, if not specified in the options
     // because we want to have a specific order of precedence, we need to remove the defaults here and merge them
     // manually in getOptions. The order of precedence is:


### PR DESCRIPTION
Hey! Thank you for the continued active work on the plugin, it is awesome! 

This PR is very similar [to my previously submitted one](https://github.com/schoero/eslint-plugin-better-tailwindcss/pull/180), but this time I've switched all valibot schemas to `strictObject` to disallow extra properties.