### PR TITLE
fix: configuration warnings getting lost

### DIFF
--- a/src/utils/lint.ts
+++ b/src/utils/lint.ts
@@ -1,4 +1,4 @@
-import { augmentMessageWithWarnings, splitClasses, splitWhitespaces } from "better-tailwindcss:utils/utils.js";
+import { splitClasses, splitWhitespaces } from "better-tailwindcss:utils/utils.js";
 
 import type { Literal } from "better-tailwindcss:types/ast.js";
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -81,11 +81,7 @@ export function lintClasses<
     }
 
     ctx.report({
-      message: augmentMessageWithWarnings(
-        `Expected ${className} to be ${result.fix ?? ""}.`,
-        ctx.docs,
-        result.warnings
-      ),
+      message: `Expected ${className} to be ${result.fix ?? ""}.`,
       range: [
         literalStart + startIndex + (literal.openingQuote?.length ?? 0) + (literal.closingBraces?.length ?? 0),
         literalStart + endIndex + (literal.openingQuote?.length ?? 0) + (literal.closingBraces?.length ?? 0)


### PR DESCRIPTION
The plugin should report when important options such as `entryPoint` are misconfigured. This PR fixes a bug where the warnings got lost.