### PR TITLE
fix: support custom css functions

### DIFF
--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -1045,4 +1045,49 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
+  it.runIf(getTailwindCSSVersion().major >= 4)(
+    "should not report on custom css functions",
+    () => {
+      lint(enforceConsistentVariableSyntax, {
+        valid: [
+          {
+            angular: `<img class="grid-cols-[--spacing(24)_1fr]" />`,
+            html: `<img class="grid-cols-[--spacing(24)_1fr]" />`,
+            jsx: `() => <img class="grid-cols-[--spacing(24)_1fr]" />`,
+            svelte: `<img class="grid-cols-[--spacing(24)_1fr]" />`,
+            vue: `<template><img class="grid-cols-[--spacing(24)_1fr]" /></template>`,
+
+            options: [{ syntax: "shorthand" }]
+          },
+          {
+            angular: `<img class="grid-cols-[--fn()]" />`,
+            html: `<img class="grid-cols-[--fn()]" />`,
+            jsx: `() => <img class="grid-cols-[--fn()]" />`,
+            svelte: `<img class="grid-cols-[--fn()]" />`,
+            vue: `<template><img class="grid-cols-[--fn()]" /></template>`,
+
+            options: [{ syntax: "shorthand" }]
+          },
+          {
+            angular: `<img class="grid-cols-[--spacing(1,2,3)]" />`,
+            html: `<img class="grid-cols-[--spacing(1,2,3)]" />`,
+            jsx: `() => <img class="grid-cols-[--spacing(1,2,3)]" />`,
+            svelte: `<img class="grid-cols-[--spacing(1,2,3)]" />`,
+            vue: `<template><img class="grid-cols-[--spacing(1,2,3)]" /></template>`,
+
+            options: [{ syntax: "shorthand" }]
+          },
+          {
+            angular: `<img class="grid-cols-[--my-func(x)]" />`,
+            html: `<img class="grid-cols-[--my-func(x)]" />`,
+            jsx: `() => <img class="grid-cols-[--my-func(x)]" />`,
+            svelte: `<img class="grid-cols-[--my-func(x)]" />`,
+            vue: `<template><img class="grid-cols-[--my-func(x)]" /></template>`,
+
+            options: [{ syntax: "shorthand" }]
+          }
+        ]
+      });
+    }
+  );
 });

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -171,7 +171,7 @@ function lintLiterals(ctx: Context<typeof enforceConsistentVariableSyntax>, lite
 }
 
 function isBeginningOfArbitraryShorthand(base: string): boolean {
-  return !!base.match(/^_*--/);
+  return !!base.match(/^_*--(?![\w-]+\()/);
 }
 
 function isBeginningOfArbitraryVariable(base: string): boolean {


### PR DESCRIPTION
Fixes an issue where css functions where considered as variables producing invalid fixes.

For example `grid-cols-[--spacing(24)_1fr]` got changed into `grid-cols-(--spacing(24)_1fr)`, which is invalid.

fixes: #305 
