### PR TITLE
feat: Support to lint curried callee

### DIFF
--- a/src/options/schemas/callees.ts
+++ b/src/options/schemas/callees.ts
@@ -1,5 +1,6 @@
 import {
   array,
+  boolean,
   description,
   optional,
   pipe,
@@ -19,34 +20,51 @@ import {
 import type { InferOutput } from "valibot";
 
 
+const CALLEE_NAME_STRING_SCHEMA = pipe(
+  string(),
+  description("Callee name for which children get linted.")
+);
+
+const CALLEE_NAME_OBJECT_SCHEMA = strictObject({
+  curried: optional(
+    pipe(
+      boolean(),
+      description("Whether to match curried function calls recursively.")
+    )
+  ),
+  name: CALLEE_NAME_STRING_SCHEMA
+});
+
+const CALLEE_NAME_SCHEMA = union([
+  CALLEE_NAME_STRING_SCHEMA,
+  CALLEE_NAME_OBJECT_SCHEMA
+]);
+
+export type CalleeNameObject = InferOutput<typeof CALLEE_NAME_OBJECT_SCHEMA>;
+export type CalleeName = InferOutput<typeof CALLEE_NAME_SCHEMA>;
+
+const CALLEE_MATCHER_LIST_SCHEMA = pipe(
+  array(
+    union([
+      STRING_MATCHER_SCHEMA,
+      OBJECT_KEY_MATCHER_SCHEMA,
+      OBJECT_VALUE_MATCHER_SCHEMA
+    ])
+  ),
+  description("List of matchers that will be applied.")
+);
+
+export type CalleeMatcherList = InferOutput<typeof CALLEE_MATCHER_LIST_SCHEMA>;
+
 const CALLEE_MATCHER_SCHEMA = pipe(
   tuple([
-    pipe(
-      string(),
-      description("Callee name for which children get linted if matched.")
-    ),
-    pipe(
-      array(
-        union([
-          STRING_MATCHER_SCHEMA,
-          OBJECT_KEY_MATCHER_SCHEMA,
-          OBJECT_VALUE_MATCHER_SCHEMA
-        ])
-      ),
-      description("List of matchers that will be applied.")
-    )
+    CALLEE_NAME_SCHEMA,
+    CALLEE_MATCHER_LIST_SCHEMA
   ]),
   description("List of matchers that will automatically be matched.")
 );
 
 export type CalleeMatchers = InferOutput<typeof CALLEE_MATCHER_SCHEMA>;
-
-const CALLEE_NAME_SCHEMA = pipe(
-  string(),
-  description("Callee name for which children get linted.")
-);
-
-export type CalleeName = InferOutput<typeof CALLEE_NAME_SCHEMA>;
 
 export const CALLEES_SCHEMA = pipe(
   array(
@@ -65,3 +83,5 @@ export const CALLEES_OPTION_SCHEMA = strictObject({
 });
 
 export type CalleesOptions = InferOutput<typeof CALLEES_OPTION_SCHEMA>;
+
+export type NormalizedCallee = [CalleeNameObject, CalleeMatcherList?];

--- a/src/utils/matchers.test.ts
+++ b/src/utils/matchers.test.ts
@@ -259,6 +259,68 @@ describe("matchers", () => {
       });
     });
 
+    it("should match callees names with curried", () => {
+      lint(noUnnecessaryWhitespace, {
+        invalid: [
+          {
+            jsx: `(state) => testStyles(state)(" lint ");`,
+            jsxOutput: `(state) => testStyles(state)("lint");`,
+            svelte: `<script>(state) => testStyles(state)(" lint ");</script>`,
+            svelteOutput: `<script>(state) => testStyles(state)("lint");</script>`,
+            vue: `<script>(state) => testStyles(state)(" lint ");</script>`,
+            vueOutput: `<script>(state) => testStyles(state)("lint");</script>`,
+
+            errors: 2,
+            options: [{
+              callees: [{ curried: true, name: "^.*Styles$" }]
+            }]
+          }
+        ],
+        valid: [
+          {
+            jsx: `(state) => testStyles(state)(" lint ");`,
+            svelte: `<script>(state) => testStyles(state)(" lint ");</script>`,
+            vue: `<script>(state) => testStyles(state)(" lint ");</script>`,
+
+            options: [{
+              callees: ["^.*Styles$"]
+            }]
+          }
+        ]
+      });
+    });
+
+    it("should match callees names with multiple curried", () => {
+      lint(noUnnecessaryWhitespace, {
+        invalid: [
+          {
+            jsx: `const x = testStyles(1)(2)(" lint ");`,
+            jsxOutput: `const x = testStyles(1)(2)("lint");`,
+            svelte: `<script>const x = testStyles(1)(2)(" lint ");</script>`,
+            svelteOutput: `<script>const x = testStyles(1)(2)("lint");</script>`,
+            vue: `<script>const x = testStyles(1)(2)(" lint ");</script>`,
+            vueOutput: `<script>const x = testStyles(1)(2)("lint");</script>`,
+
+            errors: 2,
+            options: [{
+              callees: [{ curried: true, name: "^.*Styles$" }]
+            }]
+          }
+        ],
+        valid: [
+          {
+            jsx: `const x = testStyles(1)(2)(" lint ");`,
+            svelte: `<script>const x = testStyles(1)(2)(" lint ");</script>`,
+            vue: `<script>const x = testStyles(1)(2)(" lint ");</script>`,
+
+            options: [{
+              callees: ["^.*Styles$"]
+            }]
+          }
+        ]
+      });
+    });
+
     it("should match variable names via regex", () => {
       lint(noUnnecessaryWhitespace, {
         invalid: [

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -81,11 +81,11 @@ export function matchesPathPattern(path: string, pattern: string): boolean {
 }
 
 export function isCalleeName(callee: Callees[number]): callee is CalleeName {
-  return typeof callee === "string";
+  return typeof callee === "string" || typeof callee === "object" && !Array.isArray(callee) && callee !== null && "name" in callee;
 }
 
 export function isCalleeMatchers(callee: Callees[number]): callee is CalleeMatchers {
-  return Array.isArray(callee) && typeof callee[0] === "string" && Array.isArray(callee[1]);
+  return Array.isArray(callee) && isCalleeName(callee[0]) && Array.isArray(callee[1]);
 }
 
 export function isVariableName(variable: Variables[number]): variable is VariableName {


### PR DESCRIPTION
Hello 👋 Thank you for the nice plugin 🙇

This PR is _sort of feature request_ and it's implementation,
to lint curried function's last argument.

* Example:

```ts
classNames({ isDisabled: true })(" lint ")
//                               ^^^^^^^^ We want to lint here
```

* Configuration updated in this PR:

```js
{
  "callees": [
    "classNames",
    { "name": "classNames", "curried": false },  // this will be same as `"classNames"`
    { "name": "classNames", "curried": true },
    [
      { "name": "classNames", "curried": true },
      // matchers goes here...
    ]
  ]
}
```

FYI I added some tests and confirmed that all tests and build pass on my local.

---

Why do I want this feature?

Well, our company is using `react-aria-components` and it's `className` interface is quite unique, like this:

```tsx
<Button
  className={({ isDisabled }) => `
    bg text ...
    ${isDisabled ? 'bg-gray-90' : 'bg-gray-70'}
  `}
>...</Button>
```

...and what I want to do is:

```tsx
export function MyButton({ className, ...props }) {
  return (
    <Button
      className={(renderProps) => clsxWithProps(renderProps)(
        "bg text ...",  // not get linted for now
        className
      )}
      {...props}
    />
  );
}

function clsxWithProps<T>(renderProps: T) {
  return (...args: Parameters<typeof clsx>) =>
    clsx(...args.map((arg) => (typeof arg === "function" ? arg(renderProps) : arg)));
}
```

...not like this with EVERY components:

```tsx
export function MyButton({ className, ...props }) {
  return (
    <Button
      className={(renderProps) => clsx(
        "bg text ...",
        typeof className === "function" ? className(renderProps) : className
      )}
      {...props}
    />
  );
}
```

I confirmed that above snippets get linted correctly with below eslint configuration, on this branch.

```js
import { defineConfig } from "eslint/config";
import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss";
import { getDefaultCallees } from "eslint-plugin-better-tailwindcss/defaults";

const tailwindDefaultCallees = getDefaultCallees();
const [, clsxMatcher] = tailwindDefaultCallees.find(
  ([callee]) => callee === "clsx",
);

export default defineConfig([
  {
    plugins: {
      "better-tailwindcss": eslintPluginBetterTailwindcss,
    },
    settings: {
      "better-tailwindcss": {
        entryPoint: "src/styles/index.css",
        callees: [
          ...tailwindDefaultCallees,
          [{ name: "clsxWithProps", curried: true }, clsxMatcher],
        ],
      },
    },
    rules: {
      ...eslintPluginBetterTailwindcss.configs["stylistic-warn"].rules,
      ...eslintPluginBetterTailwindcss.configs["correctness-error"].rules,
    },
  },
]);
```

---


Help needed:
* Maybe better configuration schema for this feature. Any ideas are welcome!
* Update docs, especially [/docs/configuration/advanced.md](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/configuration/advanced.md). We may have to rearrange document sections with this configuration change applies.
