### PR TITLE
refactor: rename `pathPattern` in new config

### DIFF
--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -48,7 +48,7 @@ type AttributeSelector = {
   callTarget?: "all" | "first" | "last" | number;
   match?: {
     type: "objectKeys" | "objectValues" | "strings";
-    pathPattern?: string;
+    path?: string;
   }[];
 };
 ```
@@ -58,6 +58,7 @@ type AttributeSelector = {
 - **kind**: `"callee"`.
 - **name** `optional`: regular expression for callee names.
 - **path** `optional`: regular expression for callee member paths like `classes.push`.
+  When `path` is provided, `name` is not required.
 - **callTarget** `optional`: curried call target.
   When omitted, the first call in a curried chain is used.
 - **match** `optional`: matcher list.
@@ -69,7 +70,7 @@ type CalleeSelector = {
   callTarget?: "all" | "first" | "last" | number;
   match?: {
     type: "objectKeys" | "objectValues" | "strings";
-    pathPattern?: string;
+    path?: string;
   }[];
   name?: string;
   path?: string;
@@ -89,7 +90,7 @@ type VariableSelector = {
   name: string;
   match?: {
     type: "objectKeys" | "objectValues" | "strings";
-    pathPattern?: string;
+    path?: string;
   }[];
 };
 ```
@@ -107,7 +108,7 @@ type TagSelector = {
   name: string;
   match?: {
     type: "objectKeys" | "objectValues" | "strings";
-    pathPattern?: string;
+    path?: string;
   }[];
 };
 ```
@@ -142,13 +143,13 @@ There are 3 matcher types:
 
 <br/>
 
-### `pathPattern`
+### `path`
 
-`pathPattern` lets you narrow `objectKeys` and `objectValues` matching to specific object paths.
+The `path` lets you narrow down `objectKeys` and `objectValues` matching to specific object paths.
 
 This is especially useful for libraries like [Class Variance Authority (cva)](https://cva.style/docs/getting-started/installation#intellisense), where class names appear in nested object structures.
 
-`pathPattern` is a regex matched against the object path.  
+`path` is a regex matched against the object path.  
 
 For example, the following matcher will only match object values for the `compoundVariants.class` key:
 
@@ -157,7 +158,7 @@ For example, the following matcher will only match object values for the `compou
 ```json
 {
   "type": "objectValues",
-  "pathPattern": "^compoundVariants\\[\\d+\\]\\.(?:className|class)$"
+  "path": "^compoundVariants\\[\\d+\\]\\.(?:className|class)$"
 }
 ```
 
@@ -238,7 +239,7 @@ Use `callTarget` on callee selectors to control which call in a curried chain ge
         },
         {
           "type": "objectValues",
-          "pathPattern": "^compoundVariants\\[\\d+\\]\\.(?:className|class)$"
+          "path": "^compoundVariants\\[\\d+\\]\\.(?:className|class)$"
         }
       ]
     }

--- a/src/options/callees/clb.ts
+++ b/src/options/callees/clb.ts
@@ -7,7 +7,7 @@ export const CLB_BASE_VALUES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^base$",
+      path: "^base$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -18,7 +18,7 @@ export const CLB_VARIANT_VALUES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^variants.*$",
+      path: "^variants.*$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -29,7 +29,7 @@ export const CLB_COMPOUND_VARIANTS_CLASSES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^compoundVariants\\[\\d+\\]\\.classes$",
+      path: "^compoundVariants\\[\\d+\\]\\.classes$",
       type: MatcherType.ObjectValue
     }
   ],

--- a/src/options/callees/cva.ts
+++ b/src/options/callees/cva.ts
@@ -17,7 +17,7 @@ export const CVA_VARIANT_VALUES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^variants.*$",
+      path: "^variants.*$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -28,7 +28,7 @@ export const CVA_COMPOUND_VARIANTS_CLASS = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^compoundVariants\\[\\d+\\]\\.(?:className|class)$",
+      path: "^compoundVariants\\[\\d+\\]\\.(?:className|class)$",
       type: MatcherType.ObjectValue
     }
   ],

--- a/src/options/callees/tv.ts
+++ b/src/options/callees/tv.ts
@@ -17,7 +17,7 @@ export const TV_VARIANT_VALUES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^variants.*$",
+      path: "^variants.*$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -28,7 +28,7 @@ export const TV_BASE_VALUES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^base$",
+      path: "^base$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -39,7 +39,7 @@ export const TV_SLOTS_VALUES = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^slots.*$",
+      path: "^slots.*$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -50,7 +50,7 @@ export const TV_COMPOUND_VARIANTS_CLASS = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^compoundVariants\\[\\d+\\]\\.(?:className|class).*$",
+      path: "^compoundVariants\\[\\d+\\]\\.(?:className|class).*$",
       type: MatcherType.ObjectValue
     }
   ],
@@ -61,7 +61,7 @@ export const TV_COMPOUND_SLOTS_CLASS = {
   kind: SelectorKind.Callee,
   match: [
     {
-      pathPattern: "^compoundSlots\\[\\d+\\]\\.(?:className|class).*$",
+      path: "^compoundSlots\\[\\d+\\]\\.(?:className|class).*$",
       type: MatcherType.ObjectValue
     }
   ],

--- a/src/options/migrate.test.ts
+++ b/src/options/migrate.test.ts
@@ -49,7 +49,7 @@ describe("migrate", () => {
       },
       {
         kind: SelectorKind.Variable,
-        match: [{ pathPattern: "^foo$", type: MatcherType.ObjectKey }],
+        match: [{ path: "^foo$", type: MatcherType.ObjectKey }],
         name: "^classes$"
       }
     ]);

--- a/src/options/migrate.ts
+++ b/src/options/migrate.ts
@@ -79,7 +79,7 @@ export function hasLegacySelectorConfig(options: LegacySelectorsByKind): boolean
   );
 }
 
-function toSelectorMatch(matcher: Matcher): SelectorMatcher {
+function toSelectorMatcher(matcher: Matcher): SelectorMatcher {
   if(matcher.match === MatcherType.String){
     return {
       type: matcher.match
@@ -88,7 +88,7 @@ function toSelectorMatch(matcher: Matcher): SelectorMatcher {
 
   return {
     ...matcher.pathPattern !== undefined && {
-      pathPattern: matcher.pathPattern
+      path: matcher.pathPattern
     },
     type: matcher.match
   };
@@ -102,8 +102,8 @@ function toLegacyMatcher(matcher: SelectorMatcher): Matcher {
   }
 
   return {
-    ...matcher.pathPattern !== undefined && {
-      pathPattern: matcher.pathPattern
+    ...matcher.path !== undefined && {
+      pathPattern: matcher.path
     },
     match: matcher.type
   };
@@ -119,7 +119,7 @@ function migrateLegacySelector(selector: LegacySelector, kind: SelectorKind) {
 
   return {
     kind,
-    match: selector[1].map(toSelectorMatch),
+    match: selector[1].map(toSelectorMatcher),
     name: selector[0]
   };
 }

--- a/src/options/schemas/selectors.ts
+++ b/src/options/schemas/selectors.ts
@@ -24,7 +24,7 @@ const STRING_SELECTOR_MATCHER_SCHEMA = strictObject({
 });
 
 const OBJECT_KEY_SELECTOR_MATCHER_SCHEMA = strictObject({
-  pathPattern: optional(pipe(
+  path: optional(pipe(
     string(),
     description("Regular expression that filters the object key and matches the content for further processing in a group.")
   )),
@@ -35,7 +35,7 @@ const OBJECT_KEY_SELECTOR_MATCHER_SCHEMA = strictObject({
 });
 
 const OBJECT_VALUE_SELECTOR_MATCHER_SCHEMA = strictObject({
-  pathPattern: optional(pipe(
+  path: optional(pipe(
     string(),
     description("Regular expression that filters the object value and matches the content for further processing in a group.")
   )),

--- a/src/parsers/angular.ts
+++ b/src/parsers/angular.ts
@@ -176,11 +176,11 @@ function getAngularMatcherFunctions(ctx: Rule.RuleContext, matchers: SelectorMat
 
           const path = getAngularObjectPath(ctx, ast);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }
@@ -202,11 +202,11 @@ function getAngularMatcherFunctions(ctx: Rule.RuleContext, matchers: SelectorMat
 
           const path = getAngularObjectPath(ctx, ast);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }

--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -642,11 +642,11 @@ function getESMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<ES
 
           const path = getESObjectPath(node);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }
@@ -670,11 +670,11 @@ function getESMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<ES
 
           const path = getESObjectPath(node);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -354,11 +354,11 @@ function getSvelteMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunction
 
           const path = getESObjectPath(node);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }
@@ -382,11 +382,11 @@ function getSvelteMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunction
 
           const path = getESObjectPath(node);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -225,11 +225,11 @@ function getVueMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<E
 
           const path = getESObjectPath(node);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }
@@ -253,11 +253,11 @@ function getVueMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<E
 
           const path = getESObjectPath(node);
 
-          if(!path || !matcher.pathPattern){
+          if(!path || !matcher.path){
             return true;
           }
 
-          return matchesPathPattern(path, matcher.pathPattern);
+          return matchesPathPattern(path, matcher.path);
         });
         break;
       }

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -48,12 +48,12 @@ export type SelectorStringMatcher = {
 
 export type SelectorObjectKeyMatcher = {
   type: MatcherType.ObjectKey;
-  pathPattern?: Regex | undefined;
+  path?: Regex | undefined;
 };
 
 export type SelectorObjectValueMatcher = {
   type: MatcherType.ObjectValue;
-  pathPattern?: Regex | undefined;
+  path?: Regex | undefined;
 };
 
 export type SelectorMatcher = SelectorObjectKeyMatcher | SelectorObjectValueMatcher | SelectorStringMatcher;


### PR DESCRIPTION
This pull request standardizes the matcher configuration by renaming the `pathPattern` property to `path` across the codebase, documentation, and schemas.