### PR TITLE
refactor: lint concatenated strings

### DIFF
--- a/src/parsers/es.test.ts
+++ b/src/parsers/es.test.ts
@@ -235,7 +235,7 @@ describe("es", () => {
   });
 
   // #234
-  it("should ignore literals in binary expressions", () => {
+  it("should ignore literals in binary comparisons", () => {
     lint(noUnnecessaryWhitespace, {
       valid: [
         {

--- a/src/parsers/es.ts
+++ b/src/parsers/es.ts
@@ -3,8 +3,8 @@ import {
   findMatchingParentNodes,
   getLiteralNodesByMatchers,
   isIndexedAccessLiteral,
-  isInsideBinaryExpression,
   isInsideConditionalExpressionTest,
+  isInsideDisallowedBinaryExpression,
   isInsideLogicalExpressionLeft,
   isInsideMemberExpression,
   matchesPathPattern
@@ -619,7 +619,7 @@ function getESMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<ES
             !isESNode(node) ||
             !hasESNodeParentExtension(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isIndexedAccessLiteral(node) ||
@@ -641,7 +641,7 @@ function getESMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<ES
             !hasESNodeParentExtension(node) ||
             !isESObjectKey(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isInsideMemberExpression(node) ||
@@ -667,7 +667,7 @@ function getESMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<ES
             !hasESNodeParentExtension(node) ||
             !isInsideObjectValue(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isESObjectKey(node) ||

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -12,8 +12,8 @@ import { MatcherType } from "better-tailwindcss:types/rule.js";
 import {
   getLiteralNodesByMatchers,
   isIndexedAccessLiteral,
-  isInsideBinaryExpression,
   isInsideConditionalExpressionTest,
+  isInsideDisallowedBinaryExpression,
   isInsideLogicalExpressionLeft,
   isInsideMemberExpression,
   matchesPathPattern
@@ -321,7 +321,7 @@ function getSvelteMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunction
             !isESNode(node) ||
             !hasESNodeParentExtension(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isIndexedAccessLiteral(node) ||
@@ -344,7 +344,7 @@ function getSvelteMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunction
             !hasESNodeParentExtension(node) ||
             !isESObjectKey(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isInsideMemberExpression(node) ||
@@ -370,7 +370,7 @@ function getSvelteMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunction
             !hasESNodeParentExtension(node) ||
             !isInsideObjectValue(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isESObjectKey(node) ||

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -13,8 +13,8 @@ import { MatcherType } from "better-tailwindcss:types/rule.js";
 import {
   getLiteralNodesByMatchers,
   isIndexedAccessLiteral,
-  isInsideBinaryExpression,
   isInsideConditionalExpressionTest,
+  isInsideDisallowedBinaryExpression,
   isInsideLogicalExpressionLeft,
   isInsideMemberExpression,
   matchesPathPattern
@@ -192,7 +192,7 @@ function getVueMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<E
             !isESNode(node) ||
             !hasESNodeParentExtension(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isIndexedAccessLiteral(node) ||
@@ -214,7 +214,7 @@ function getVueMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<E
             !hasESNodeParentExtension(node) ||
             !isESObjectKey(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isInsideMemberExpression(node) ||
@@ -240,7 +240,7 @@ function getVueMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions<E
             !hasESNodeParentExtension(node) ||
             !isInsideObjectValue(node) ||
 
-            isInsideBinaryExpression(node) ||
+            isInsideDisallowedBinaryExpression(node) ||
             isInsideConditionalExpressionTest(node) ||
             isInsideLogicalExpressionLeft(node) ||
             isESObjectKey(node) ||

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -119,10 +119,13 @@ export function isInsideConditionalExpressionTest(node: WithParent<ESNode>): boo
   return isInsideConditionalExpressionTest(node.parent);
 }
 
-export function isInsideBinaryExpression(node: WithParent<ESNode>): boolean {
+export function isInsideDisallowedBinaryExpression(node: WithParent<ESNode>): boolean {
   if(!hasESNodeParentExtension(node)){ return false; }
-  if(node.parent.type === "BinaryExpression"){ return true; }
-  return isInsideBinaryExpression(node.parent);
+  if(
+    node.parent.type === "BinaryExpression" &&
+    node.parent.operator !== "+" // allow string concatenation
+  ){ return true; }
+  return isInsideDisallowedBinaryExpression(node.parent);
 }
 
 export function isInsideLogicalExpressionLeft(node: WithParent<ESNode>): boolean {


### PR DESCRIPTION
Enables linting for concatenated strings:

```tsx
<img class={"flex " + "rounded"} />
```