### PR TITLE
fix: only sort variants that are safe

### DIFF
--- a/src/async-utils/order.ts
+++ b/src/async-utils/order.ts
@@ -1,0 +1,3 @@
+export enum VARIANT_ORDER_FLAGS {
+  GLOBAL = 1 << 16
+}

--- a/src/rules/enforce-consistent-variant-order.test.ts
+++ b/src/rules/enforce-consistent-variant-order.test.ts
@@ -273,6 +273,14 @@ describe.runIf(getTailwindCSSVersion().major >= 4)(enforceConsistentVariantOrder
           jsx: `() => <img class="hover:**:text-red-500" />`,
           svelte: `<img class="hover:**:text-red-500" />`,
           vue: `<template><img class="hover:**:text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="*:first:appearance-auto" />`,
+          astro: `<img class="*:first:appearance-auto" />`,
+          html: `<img class="*:first:appearance-auto" />`,
+          jsx: `() => <img class="*:first:appearance-auto" />`,
+          svelte: `<img class="*:first:appearance-auto" />`,
+          vue: `<template><img class="*:first:appearance-auto" /></template>`
         }
       ]
     });

--- a/src/rules/enforce-consistent-variant-order.test.ts
+++ b/src/rules/enforce-consistent-variant-order.test.ts
@@ -7,7 +7,7 @@ import { getTailwindCSSVersion } from "better-tailwindcss:tests/utils/version.js
 
 describe.runIf(getTailwindCSSVersion().major >= 4)(enforceConsistentVariantOrder.name, () => {
 
-  it("should enforce Tailwind's variant order", () => {
+  it("should move global variants to the beginning", () => {
     lint(enforceConsistentVariantOrder, {
       invalid: [
         {
@@ -27,158 +27,283 @@ describe.runIf(getTailwindCSSVersion().major >= 4)(enforceConsistentVariantOrder
           errors: 1
         },
         {
-          angular: `<img class="hover:focus:text-red-500" />`,
-          angularOutput: `<img class="focus:hover:text-red-500" />`,
-          astro: `<img class="hover:focus:text-red-500" />`,
-          astroOutput: `<img class="focus:hover:text-red-500" />`,
-          html: `<img class="hover:focus:text-red-500" />`,
-          htmlOutput: `<img class="focus:hover:text-red-500" />`,
-          jsx: `() => <img class="hover:focus:text-red-500" />`,
-          jsxOutput: `() => <img class="focus:hover:text-red-500" />`,
-          svelte: `<img class="hover:focus:text-red-500" />`,
-          svelteOutput: `<img class="focus:hover:text-red-500" />`,
-          vue: `<template><img class="hover:focus:text-red-500" /></template>`,
-          vueOutput: `<template><img class="focus:hover:text-red-500" /></template>`,
+          angular: `<img class="focus:hover:lg:text-red-500" />`,
+          angularOutput: `<img class="lg:focus:hover:text-red-500" />`,
+          astro: `<img class="focus:hover:lg:text-red-500" />`,
+          astroOutput: `<img class="lg:focus:hover:text-red-500" />`,
+          html: `<img class="focus:hover:lg:text-red-500" />`,
+          htmlOutput: `<img class="lg:focus:hover:text-red-500" />`,
+          jsx: `() => <img class="focus:hover:lg:text-red-500" />`,
+          jsxOutput: `() => <img class="lg:focus:hover:text-red-500" />`,
+          svelte: `<img class="focus:hover:lg:text-red-500" />`,
+          svelteOutput: `<img class="lg:focus:hover:text-red-500" />`,
+          vue: `<template><img class="focus:hover:lg:text-red-500" /></template>`,
+          vueOutput: `<template><img class="lg:focus:hover:text-red-500" /></template>`,
 
           errors: 1
-        }
-      ],
-      valid: [
-        {
-          angular: `<img class="lg:hover:text-red-500" />`,
-          astro: `<img class="lg:hover:text-red-500" />`,
-          html: `<img class="lg:hover:text-red-500" />`,
-          jsx: `() => <img class="lg:hover:text-red-500" />`,
-          svelte: `<img class="lg:hover:text-red-500" />`,
-          vue: `<template><img class="lg:hover:text-red-500" /></template>`
         },
         {
-          angular: `<img class="focus:hover:text-red-500" />`,
-          astro: `<img class="focus:hover:text-red-500" />`,
-          html: `<img class="focus:hover:text-red-500" />`,
-          jsx: `() => <img class="focus:hover:text-red-500" />`,
-          svelte: `<img class="focus:hover:text-red-500" />`,
-          vue: `<template><img class="focus:hover:text-red-500" /></template>`
+          angular: `<img class="hover:lg:dark:text-red-500" />`,
+          angularOutput: `<img class="dark:lg:hover:text-red-500" />`,
+          astro: `<img class="hover:lg:dark:text-red-500" />`,
+          astroOutput: `<img class="dark:lg:hover:text-red-500" />`,
+          html: `<img class="hover:lg:dark:text-red-500" />`,
+          htmlOutput: `<img class="dark:lg:hover:text-red-500" />`,
+          jsx: `() => <img class="hover:lg:dark:text-red-500" />`,
+          jsxOutput: `() => <img class="dark:lg:hover:text-red-500" />`,
+          svelte: `<img class="hover:lg:dark:text-red-500" />`,
+          svelteOutput: `<img class="dark:lg:hover:text-red-500" />`,
+          vue: `<template><img class="hover:lg:dark:text-red-500" /></template>`,
+          vueOutput: `<template><img class="dark:lg:hover:text-red-500" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should treat media and feature-query variants as global", () => {
+    lint(enforceConsistentVariantOrder, {
+      invalid: [
+        {
+          angular: `<img class="hover:print:text-red-500" />`,
+          angularOutput: `<img class="print:hover:text-red-500" />`,
+          astro: `<img class="hover:print:text-red-500" />`,
+          astroOutput: `<img class="print:hover:text-red-500" />`,
+          html: `<img class="hover:print:text-red-500" />`,
+          htmlOutput: `<img class="print:hover:text-red-500" />`,
+          jsx: `() => <img class="hover:print:text-red-500" />`,
+          jsxOutput: `() => <img class="print:hover:text-red-500" />`,
+          svelte: `<img class="hover:print:text-red-500" />`,
+          svelteOutput: `<img class="print:hover:text-red-500" />`,
+          vue: `<template><img class="hover:print:text-red-500" /></template>`,
+          vueOutput: `<template><img class="print:hover:text-red-500" /></template>`,
+
+          errors: 1
         },
         {
-          angular: `<img class="text-red-500" />`,
-          astro: `<img class="text-red-500" />`,
-          html: `<img class="text-red-500" />`,
-          jsx: `() => <img class="text-red-500" />`,
-          svelte: `<img class="text-red-500" />`,
-          vue: `<template><img class="text-red-500" /></template>`
-        }
-      ]
-    });
-  });
+          angular: `<img class="hover:motion-reduce:text-red-500" />`,
+          angularOutput: `<img class="motion-reduce:hover:text-red-500" />`,
+          astro: `<img class="hover:motion-reduce:text-red-500" />`,
+          astroOutput: `<img class="motion-reduce:hover:text-red-500" />`,
+          html: `<img class="hover:motion-reduce:text-red-500" />`,
+          htmlOutput: `<img class="motion-reduce:hover:text-red-500" />`,
+          jsx: `() => <img class="hover:motion-reduce:text-red-500" />`,
+          jsxOutput: `() => <img class="motion-reduce:hover:text-red-500" />`,
+          svelte: `<img class="hover:motion-reduce:text-red-500" />`,
+          svelteOutput: `<img class="motion-reduce:hover:text-red-500" />`,
+          vue: `<template><img class="hover:motion-reduce:text-red-500" /></template>`,
+          vueOutput: `<template><img class="motion-reduce:hover:text-red-500" /></template>`,
 
-  it("should support arbitrary variants", () => {
-    lint(enforceConsistentVariantOrder, {
-      invalid: [
+          errors: 1
+        },
         {
-          angular: `<img class="active:[&.is-dragging]:cursor-grabbing" />`,
-          angularOutput: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          astro: `<img class="active:[&.is-dragging]:cursor-grabbing" />`,
-          astroOutput: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          html: `<img class="active:[&.is-dragging]:cursor-grabbing" />`,
-          htmlOutput: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          jsx: `() => <img class="active:[&.is-dragging]:cursor-grabbing" />`,
-          jsxOutput: `() => <img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          svelte: `<img class="active:[&.is-dragging]:cursor-grabbing" />`,
-          svelteOutput: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          vue: `<template><img class="active:[&.is-dragging]:cursor-grabbing" /></template>`,
-          vueOutput: `<template><img class="[&.is-dragging]:active:cursor-grabbing" /></template>`,
+          angular: `<img class="hover:forced-colors:text-red-500" />`,
+          angularOutput: `<img class="forced-colors:hover:text-red-500" />`,
+          astro: `<img class="hover:forced-colors:text-red-500" />`,
+          astroOutput: `<img class="forced-colors:hover:text-red-500" />`,
+          html: `<img class="hover:forced-colors:text-red-500" />`,
+          htmlOutput: `<img class="forced-colors:hover:text-red-500" />`,
+          jsx: `() => <img class="hover:forced-colors:text-red-500" />`,
+          jsxOutput: `() => <img class="forced-colors:hover:text-red-500" />`,
+          svelte: `<img class="hover:forced-colors:text-red-500" />`,
+          svelteOutput: `<img class="forced-colors:hover:text-red-500" />`,
+          vue: `<template><img class="hover:forced-colors:text-red-500" /></template>`,
+          vueOutput: `<template><img class="forced-colors:hover:text-red-500" /></template>`,
 
           errors: 1
         }
       ],
       valid: [
         {
-          angular: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          astro: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          html: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          jsx: `() => <img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          svelte: `<img class="[&.is-dragging]:active:cursor-grabbing" />`,
-          vue: `<template><img class="[&.is-dragging]:active:cursor-grabbing" /></template>`
+          angular: `<img class="print:hover:text-red-500" />`,
+          astro: `<img class="print:hover:text-red-500" />`,
+          html: `<img class="print:hover:text-red-500" />`,
+          jsx: `() => <img class="print:hover:text-red-500" />`,
+          svelte: `<img class="print:hover:text-red-500" />`,
+          vue: `<template><img class="print:hover:text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="motion-reduce:hover:text-red-500" />`,
+          astro: `<img class="motion-reduce:hover:text-red-500" />`,
+          html: `<img class="motion-reduce:hover:text-red-500" />`,
+          jsx: `() => <img class="motion-reduce:hover:text-red-500" />`,
+          svelte: `<img class="motion-reduce:hover:text-red-500" />`,
+          vue: `<template><img class="motion-reduce:hover:text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="forced-colors:hover:text-red-500" />`,
+          astro: `<img class="forced-colors:hover:text-red-500" />`,
+          html: `<img class="forced-colors:hover:text-red-500" />`,
+          jsx: `() => <img class="forced-colors:hover:text-red-500" />`,
+          svelte: `<img class="forced-colors:hover:text-red-500" />`,
+          vue: `<template><img class="forced-colors:hover:text-red-500" /></template>`
         }
       ]
     });
   });
 
-  it("should support compound variants", () => {
+  it("should support sorting around arbitrary variants", () => {
     lint(enforceConsistentVariantOrder, {
       invalid: [
         {
-          angular: `<img class="group-[&:focus]:hover:text-red-500" />`,
-          angularOutput: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          astro: `<img class="group-[&:focus]:hover:text-red-500" />`,
-          astroOutput: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          html: `<img class="group-[&:focus]:hover:text-red-500" />`,
-          htmlOutput: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          jsx: `() => <img class="group-[&:focus]:hover:text-red-500" />`,
-          jsxOutput: `() => <img class="hover:group-[&:focus]:text-red-500" />`,
-          svelte: `<img class="group-[&:focus]:hover:text-red-500" />`,
-          svelteOutput: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          vue: `<template><img class="group-[&:focus]:hover:text-red-500" /></template>`,
-          vueOutput: `<template><img class="hover:group-[&:focus]:text-red-500" /></template>`,
+          angular: `<img class="[&.is-dragging]:lg:cursor-grabbing" />`,
+          angularOutput: `<img class="lg:[&.is-dragging]:cursor-grabbing" />`,
+          astro: `<img class="[&.is-dragging]:lg:cursor-grabbing" />`,
+          astroOutput: `<img class="lg:[&.is-dragging]:cursor-grabbing" />`,
+          html: `<img class="[&.is-dragging]:lg:cursor-grabbing" />`,
+          htmlOutput: `<img class="lg:[&.is-dragging]:cursor-grabbing" />`,
+          jsx: `() => <img class="[&.is-dragging]:lg:cursor-grabbing" />`,
+          jsxOutput: `() => <img class="lg:[&.is-dragging]:cursor-grabbing" />`,
+          svelte: `<img class="[&.is-dragging]:lg:cursor-grabbing" />`,
+          svelteOutput: `<img class="lg:[&.is-dragging]:cursor-grabbing" />`,
+          vue: `<template><img class="[&.is-dragging]:lg:cursor-grabbing" /></template>`,
+          vueOutput: `<template><img class="lg:[&.is-dragging]:cursor-grabbing" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should preserve modifiers when sorting variants", () => {
+    lint(enforceConsistentVariantOrder, {
+      invalid: [
+        {
+          angular: `<img class="group-hover/name:lg:text-red-500" />`,
+          angularOutput: `<img class="lg:group-hover/name:text-red-500" />`,
+          astro: `<img class="group-hover/name:lg:text-red-500" />`,
+          astroOutput: `<img class="lg:group-hover/name:text-red-500" />`,
+          html: `<img class="group-hover/name:lg:text-red-500" />`,
+          htmlOutput: `<img class="lg:group-hover/name:text-red-500" />`,
+          jsx: `() => <img class="group-hover/name:lg:text-red-500" />`,
+          jsxOutput: `() => <img class="lg:group-hover/name:text-red-500" />`,
+          svelte: `<img class="group-hover/name:lg:text-red-500" />`,
+          svelteOutput: `<img class="lg:group-hover/name:text-red-500" />`,
+          vue: `<template><img class="group-hover/name:lg:text-red-500" /></template>`,
+          vueOutput: `<template><img class="lg:group-hover/name:text-red-500" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should treat child selector variants as non-global", () => {
+    lint(enforceConsistentVariantOrder, {
+      invalid: [
+        {
+          angular: `<img class="*:lg:text-red-500" />`,
+          angularOutput: `<img class="lg:*:text-red-500" />`,
+          astro: `<img class="*:lg:text-red-500" />`,
+          astroOutput: `<img class="lg:*:text-red-500" />`,
+          html: `<img class="*:lg:text-red-500" />`,
+          htmlOutput: `<img class="lg:*:text-red-500" />`,
+          jsx: `() => <img class="*:lg:text-red-500" />`,
+          jsxOutput: `() => <img class="lg:*:text-red-500" />`,
+          svelte: `<img class="*:lg:text-red-500" />`,
+          svelteOutput: `<img class="lg:*:text-red-500" />`,
+          vue: `<template><img class="*:lg:text-red-500" /></template>`,
+          vueOutput: `<template><img class="lg:*:text-red-500" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="**:lg:text-red-500" />`,
+          angularOutput: `<img class="lg:**:text-red-500" />`,
+          astro: `<img class="**:lg:text-red-500" />`,
+          astroOutput: `<img class="lg:**:text-red-500" />`,
+          html: `<img class="**:lg:text-red-500" />`,
+          htmlOutput: `<img class="lg:**:text-red-500" />`,
+          jsx: `() => <img class="**:lg:text-red-500" />`,
+          jsxOutput: `() => <img class="lg:**:text-red-500" />`,
+          svelte: `<img class="**:lg:text-red-500" />`,
+          svelteOutput: `<img class="lg:**:text-red-500" />`,
+          vue: `<template><img class="**:lg:text-red-500" /></template>`,
+          vueOutput: `<template><img class="lg:**:text-red-500" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="*:**:lg:text-red-500" />`,
+          angularOutput: `<img class="lg:*:**:text-red-500" />`,
+          astro: `<img class="*:**:lg:text-red-500" />`,
+          astroOutput: `<img class="lg:*:**:text-red-500" />`,
+          html: `<img class="*:**:lg:text-red-500" />`,
+          htmlOutput: `<img class="lg:*:**:text-red-500" />`,
+          jsx: `() => <img class="*:**:lg:text-red-500" />`,
+          jsxOutput: `() => <img class="lg:*:**:text-red-500" />`,
+          svelte: `<img class="*:**:lg:text-red-500" />`,
+          svelteOutput: `<img class="lg:*:**:text-red-500" />`,
+          vue: `<template><img class="*:**:lg:text-red-500" /></template>`,
+          vueOutput: `<template><img class="lg:*:**:text-red-500" /></template>`,
 
           errors: 1
         }
       ],
       valid: [
         {
-          angular: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          astro: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          html: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          jsx: `() => <img class="hover:group-[&:focus]:text-red-500" />`,
-          svelte: `<img class="hover:group-[&:focus]:text-red-500" />`,
-          vue: `<template><img class="hover:group-[&:focus]:text-red-500" /></template>`
+          angular: `<img class="*:hover:text-red-500" />`,
+          astro: `<img class="*:hover:text-red-500" />`,
+          html: `<img class="*:hover:text-red-500" />`,
+          jsx: `() => <img class="*:hover:text-red-500" />`,
+          svelte: `<img class="*:hover:text-red-500" />`,
+          vue: `<template><img class="*:hover:text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="hover:*:text-red-500" />`,
+          astro: `<img class="hover:*:text-red-500" />`,
+          html: `<img class="hover:*:text-red-500" />`,
+          jsx: `() => <img class="hover:*:text-red-500" />`,
+          svelte: `<img class="hover:*:text-red-500" />`,
+          vue: `<template><img class="hover:*:text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="**:hover:text-red-500" />`,
+          astro: `<img class="**:hover:text-red-500" />`,
+          html: `<img class="**:hover:text-red-500" />`,
+          jsx: `() => <img class="**:hover:text-red-500" />`,
+          svelte: `<img class="**:hover:text-red-500" />`,
+          vue: `<template><img class="**:hover:text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="hover:**:text-red-500" />`,
+          astro: `<img class="hover:**:text-red-500" />`,
+          html: `<img class="hover:**:text-red-500" />`,
+          jsx: `() => <img class="hover:**:text-red-500" />`,
+          svelte: `<img class="hover:**:text-red-500" />`,
+          vue: `<template><img class="hover:**:text-red-500" /></template>`
         }
       ]
     });
   });
 
-  it("should support custom variants", () => {
+  it("should support custom breakpoints", () => {
     lint(enforceConsistentVariantOrder, {
       invalid: [
         {
-          angular: `<img class="hover:theme-midnight:text-white" />`,
-          angularOutput: `<img class="theme-midnight:hover:text-white" />`,
-          astro: `<img class="hover:theme-midnight:text-white" />`,
-          astroOutput: `<img class="theme-midnight:hover:text-white" />`,
-          html: `<img class="hover:theme-midnight:text-white" />`,
-          htmlOutput: `<img class="theme-midnight:hover:text-white" />`,
-          jsx: `() => <img class="hover:theme-midnight:text-white" />`,
-          jsxOutput: `() => <img class="theme-midnight:hover:text-white" />`,
-          svelte: `<img class="hover:theme-midnight:text-white" />`,
-          svelteOutput: `<img class="theme-midnight:hover:text-white" />`,
-          vue: `<template><img class="hover:theme-midnight:text-white" /></template>`,
-          vueOutput: `<template><img class="theme-midnight:hover:text-white" /></template>`,
+          angular: `<img class="hover:desktop:text-white" />`,
+          angularOutput: `<img class="desktop:hover:text-white" />`,
+          astro: `<img class="hover:desktop:text-white" />`,
+          astroOutput: `<img class="desktop:hover:text-white" />`,
+          html: `<img class="hover:desktop:text-white" />`,
+          htmlOutput: `<img class="desktop:hover:text-white" />`,
+          jsx: `() => <img class="hover:desktop:text-white" />`,
+          jsxOutput: `() => <img class="desktop:hover:text-white" />`,
+          svelte: `<img class="hover:desktop:text-white" />`,
+          svelteOutput: `<img class="desktop:hover:text-white" />`,
+          vue: `<template><img class="hover:desktop:text-white" /></template>`,
+          vueOutput: `<template><img class="desktop:hover:text-white" /></template>`,
 
           errors: 1,
 
           files: {
             "styles.css": `
               @import "tailwindcss";
-              @custom-variant theme-midnight (&:where([data-theme="midnight"] *));
-            `
-          },
-          options: [{ entryPoint: "styles.css" }]
-        }
-      ],
-      valid: [
-        {
-          angular: `<img class="theme-midnight:hover:text-white" />`,
-          astro: `<img class="theme-midnight:hover:text-white" />`,
-          html: `<img class="theme-midnight:hover:text-white" />`,
-          jsx: `() => <img class="theme-midnight:hover:text-white" />`,
-          svelte: `<img class="theme-midnight:hover:text-white" />`,
-          vue: `<template><img class="theme-midnight:hover:text-white" /></template>`,
 
-          files: {
-            "styles.css": `
-              @import "tailwindcss";
-              @custom-variant theme-midnight (&:where([data-theme="midnight"] *));
+              @theme {
+                --breakpoint-desktop: 80rem;
+              }
             `
           },
 

--- a/src/rules/enforce-consistent-variant-order.ts
+++ b/src/rules/enforce-consistent-variant-order.ts
@@ -3,6 +3,7 @@ import { createGetVariantOrder, getVariantOrder } from "better-tailwindcss:tailw
 import { buildClass } from "better-tailwindcss:utils/class.js";
 import { async } from "better-tailwindcss:utils/context.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
+import { VARIANT_ORDER_FLAGS } from "better-tailwindcss:utils/order.js";
 import { createRule } from "better-tailwindcss:utils/rule.js";
 import { splitClasses } from "better-tailwindcss:utils/utils.js";
 
@@ -57,7 +58,6 @@ export const enforceConsistentVariantOrder = createRule({
           return false;
         }
 
-
         const fix = buildClass(ctx, {
           ...dissectedClass,
           variants: sortedVariants
@@ -78,18 +78,19 @@ export const enforceConsistentVariantOrder = createRule({
 });
 
 function compareVariantOrder(orderA: number | undefined, orderB: number | undefined): number {
-  if(orderA === orderB){
+  if(
+    orderA === orderB ||
+    orderA === undefined ||
+    orderB === undefined ||
+    orderA < VARIANT_ORDER_FLAGS.GLOBAL &&
+    orderB < VARIANT_ORDER_FLAGS.GLOBAL
+  ){
     return 0;
   }
 
-  if(orderA === undefined){
+  if(orderB > orderA){
     return +1;
   }
 
-  if(orderB === undefined){
-    return -1;
-  }
-
-  // Match Tailwind language service behavior: variants with higher order index come first.
-  return +(orderB - orderA > 0) - +(orderB - orderA < 0);
+  return -1;
 }

--- a/src/tailwindcss/variant-order.async.v4.ts
+++ b/src/tailwindcss/variant-order.async.v4.ts
@@ -1,25 +1,50 @@
+import { VARIANT_ORDER_FLAGS } from "../async-utils/order.js";
+
 import type { VariantOrder } from "./variant-order.js";
 
 
 export function getVariantOrder(tailwindContext: any, classes: string[]): VariantOrder {
-  const uniqueClasses = [...new Set(classes)];
-
-  if(uniqueClasses.length <= 0){
-    return {};
-  }
-
-  // Tailwind tracks parsed variants internally and exposes grouped order via getVariantOrder().
-  // Parse classes first so all encountered variants are known to that internal set.
-  for(const className of uniqueClasses){
-    tailwindContext.parseCandidate(className);
-  }
+  const candidates = classes.map(className => tailwindContext.parseCandidate(className));
 
   const variantOrder = tailwindContext.getVariantOrder();
+  const variants = tailwindContext.getVariants();
 
-  return [...variantOrder.entries()].reduce<VariantOrder>((acc, [variant, order]) => {
-    const variantName = tailwindContext.printVariant(variant);
-    acc[variantName] ??= order;
+  const variantsByName = new Map(
+    (variants ?? []).map(variant => {
+      return [variant.name, variant];
+    })
+  );
+  const variantOrderByName = new Map(
+    [...variantOrder.entries()].map(([variant, order]) => {
+      return [tailwindContext.printVariant(variant), order];
+    })
+  );
+
+  return candidates.reduce<VariantOrder>((acc, candidates) => {
+    for(const candidate of candidates ?? []){
+      for(const variantCandidate of candidate?.variants ?? []){
+        const variantName = tailwindContext.printVariant(variantCandidate);
+        const variant = variantsByName.get(variantName);
+        const twOrder = variantOrderByName.get(variantName) || 0;
+        const globalOrder = hasGlobalSelector(variant) ? VARIANT_ORDER_FLAGS.GLOBAL : 0;
+
+        acc[variantName] ??= globalOrder | twOrder;
+      }
+    }
 
     return acc;
   }, {});
+}
+
+
+function hasGlobalSelector(variant: any): boolean {
+  const selectors = variant?.selectors?.();
+
+  if(!Array.isArray(selectors) || selectors.length <= 0){
+    return false;
+  }
+
+  return selectors.every(selector => {
+    return typeof selector === "string" && !selector.includes("&");
+  });
 }

--- a/src/tailwindcss/variant-order.async.v4.ts
+++ b/src/tailwindcss/variant-order.async.v4.ts
@@ -20,8 +20,8 @@ export function getVariantOrder(tailwindContext: any, classes: string[]): Varian
     })
   );
 
-  return candidates.reduce<VariantOrder>((acc, candidates) => {
-    for(const candidate of candidates ?? []){
+  return candidates.reduce<VariantOrder>((acc, parsedCandidates) => {
+    for(const candidate of parsedCandidates ?? []){
       for(const variantCandidate of candidate?.variants ?? []){
         const variantName = tailwindContext.printVariant(variantCandidate);
         const variant = variantsByName.get(variantName);


### PR DESCRIPTION
Makes `enforce-consistent-variant-order` safe.

This PR disables sorting for variants that change scope, such as child selectors like `*:`, `**:`, or `first-child:`. Only global variants, like `lg:`, are now sorted.

This can be expanded in the future.

fixes: #363 