### PR TITLE
feat: add `ignore` option to `enforce-canonical-classes`

### DIFF
--- a/docs/rules/enforce-canonical-classes.md
+++ b/docs/rules/enforce-canonical-classes.md
@@ -61,7 +61,7 @@ Whether to convert between logical and physical properties when collapsing utili
 
 ### `ignore`
 
-List of classes that should not report a canonical suggestion. The entries in this list are treated as regular expressions.
+List of List of regex patterns for classes that should not report a canonical suggestion.
 
 This can be useful for cases where a non-canonical class representation is intentional.
 

--- a/docs/rules/enforce-canonical-classes.md
+++ b/docs/rules/enforce-canonical-classes.md
@@ -59,6 +59,17 @@ Whether to convert between logical and physical properties when collapsing utili
 
 <br/>
 
+### `ignore`
+
+List of classes that should not report a canonical suggestion. The entries in this list are treated as regular expressions.
+
+This can be useful for cases where a non-canonical class representation is intentional.
+
+**Type**: `string[]`  
+**Default**: `[]`
+
+<br/>
+
 <details>
   <summary>Common options</summary>
 

--- a/docs/rules/no-unknown-classes.md
+++ b/docs/rules/no-unknown-classes.md
@@ -8,7 +8,7 @@ Disallow unknown classes in Tailwind CSS class strings. Unknown classes are clas
 
 ### `ignore`
 
-  List of classes that should not report an error. The entries in this list are treated as regular expressions.
+  List of List of regex patterns for classes that should not report an error.
   
   **Type**: `string[]`  
   **Default**: `[]`

--- a/src/rules/enforce-canonical-classes.test.ts
+++ b/src/rules/enforce-canonical-classes.test.ts
@@ -327,6 +327,43 @@ describe.runIf(getTailwindCSSVersion().major >= 4)(enforceCanonicalClasses.name,
     });
   });
 
+  // #369
+  it("should be possible to ignore classes that match specific patterns", () => {
+    lint(enforceCanonicalClasses, {
+      invalid: [
+        {
+          angular: `<img class="-mt-[0.04in] [color:red]/100" />`,
+          angularOutput: `<img class="-mt-[0.04in] text-[red]" />`,
+          html: `<img class="-mt-[0.04in] [color:red]/100" />`,
+          htmlOutput: `<img class="-mt-[0.04in] text-[red]" />`,
+          jsx: `() => <img class="-mt-[0.04in] [color:red]/100" />`,
+          jsxOutput: `() => <img class="-mt-[0.04in] text-[red]" />`,
+          svelte: `<img class="-mt-[0.04in] [color:red]/100" />`,
+          svelteOutput: `<img class="-mt-[0.04in] text-[red]" />`,
+          vue: `<template><img class="-mt-[0.04in] [color:red]/100" /></template>`,
+          vueOutput: `<template><img class="-mt-[0.04in] text-[red]" /></template>`,
+
+          errors: [{
+            message: values(enforceCanonicalClasses.messages!.single, {
+              canonicalClass: "text-[red]",
+              className: "[color:red]/100"
+            })
+          }],
+
+          files: {
+            "styles.css": css`
+              @import "tailwindcss";
+            `
+          },
+          options: [{
+            entryPoint: "styles.css",
+            ignore: ["^\\S*\\[.*in\\]$"]
+          }]
+        }
+      ]
+    });
+  });
+
   // #304
   it("should not remove unrelated classes when simplifying", { timeout: 30_000 }, () => {
     lint(enforceCanonicalClasses, {

--- a/src/rules/enforce-canonical-classes.ts
+++ b/src/rules/enforce-canonical-classes.ts
@@ -40,7 +40,7 @@ export const enforceCanonicalClasses = createRule({
         array(
           string()
         ),
-        description("A list of classes that should be ignored by the rule.")
+        description("A list of regular expression patterns for classes that should be ignored by the rule.")
       ),
       []
     ),

--- a/src/rules/enforce-canonical-classes.ts
+++ b/src/rules/enforce-canonical-classes.ts
@@ -66,14 +66,14 @@ export const enforceCanonicalClasses = createRule({
 });
 
 function lintLiterals(ctx: Context<typeof enforceCanonicalClasses>, literals: Literal[]) {
+  const { collapse, ignore, logical, rootFontSize } = ctx.options;
+  const ignoredClassRegexes = ignore.map(ignoredClass => getCachedRegex(ignoredClass));
+
   for(const literal of literals){
 
     const classes = splitClasses(literal.content);
     const uniqueClasses = deduplicateClasses(classes);
 
-    const { collapse, ignore, logical, rootFontSize } = ctx.options;
-
-    const ignoredClassRegexes = ignore.map(ignoredClass => getCachedRegex(ignoredClass));
     const filteredUniqueClasses = uniqueClasses.filter(className => !ignoredClassRegexes.some(ignoredClassRegex => ignoredClassRegex.test(className)));
 
     if(filteredUniqueClasses.length === 0){

--- a/src/rules/enforce-canonical-classes.ts
+++ b/src/rules/enforce-canonical-classes.ts
@@ -1,8 +1,17 @@
-import { boolean, description, optional, pipe, strictObject } from "valibot";
+import {
+  array,
+  boolean,
+  description,
+  optional,
+  pipe,
+  strictObject,
+  string
+} from "valibot";
 
 import { createGetCanonicalClasses, getCanonicalClasses } from "better-tailwindcss:tailwindcss/canonical-classes.js";
 import { async } from "better-tailwindcss:utils/context.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
+import { getCachedRegex } from "better-tailwindcss:utils/regex.js";
 import { createRule } from "better-tailwindcss:utils/rule.js";
 import { deduplicateClasses, splitClasses } from "better-tailwindcss:utils/utils.js";
 
@@ -25,6 +34,15 @@ export const enforceCanonicalClasses = createRule({
         description("Whether to collapse multiple utilities into a single utility if possible.")
       ),
       true
+    ),
+    ignore: optional(
+      pipe(
+        array(
+          string()
+        ),
+        description("A list of classes that should be ignored by the rule.")
+      ),
+      []
     ),
     logical: optional(
       pipe(
@@ -53,9 +71,16 @@ function lintLiterals(ctx: Context<typeof enforceCanonicalClasses>, literals: Li
     const classes = splitClasses(literal.content);
     const uniqueClasses = deduplicateClasses(classes);
 
-    const { collapse, logical, rootFontSize } = ctx.options;
+    const { collapse, ignore, logical, rootFontSize } = ctx.options;
 
-    const { canonicalClasses, warnings } = getCanonicalClasses(async(ctx), uniqueClasses, {
+    const ignoredClassRegexes = ignore.map(ignoredClass => getCachedRegex(ignoredClass));
+    const filteredUniqueClasses = uniqueClasses.filter(className => !ignoredClassRegexes.some(ignoredClassRegex => ignoredClassRegex.test(className)));
+
+    if(filteredUniqueClasses.length === 0){
+      continue;
+    }
+
+    const { canonicalClasses, warnings } = getCanonicalClasses(async(ctx), filteredUniqueClasses, {
       collapse,
       logicalToPhysical: logical,
       rem: rootFontSize

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -35,7 +35,7 @@ export const noUnknownClasses = createRule({
         array(
           string()
         ),
-        description("A list of classes that should be ignored by the rule.")
+        description("A list of regular expression patterns for classes that should be ignored by the rule.")
       ),
       []
     )


### PR DESCRIPTION
Adds a `ignore` option to [`enforce-canonical-classes`](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-canonical-classes.md#options).

This allows to ignore classes that match specific patterns. For example it is possible to ignore classes with `cm`, `mm` or `in` units that are commonly used for printing:

```json
{
  "ignore":  ["^\\S*\\[.*in\\]$"]
}
```

```html
<div class="m-[0.04in]></div>
```

closes: #369 