### PR TITLE
feat(no-unknown-classes): detect classes from Svelte style blocks

### DIFF
--- a/docs/rules/no-unknown-classes.md
+++ b/docs/rules/no-unknown-classes.md
@@ -26,6 +26,29 @@ Disallow unknown classes in Tailwind CSS class strings. Unknown classes are clas
 
 <br/>
 
+### `detectSvelteStyleClasses`
+
+  Treat class selectors declared in a Svelte component's `<style>` block as known classes for that component.
+
+  The option only has an effect in `.svelte` files. If the `<style>` block cannot be parsed, or it uses a style language that `svelte-eslint-parser` cannot parse, no classes are detected from it.
+
+  **Type**: `boolean`  
+  **Default**: `false`
+
+  This is useful when a `.svelte` file mixes Tailwind classes with local component classes:
+
+  ```svelte
+  <style>
+    .card {
+      border-radius: 0.5rem;
+    }
+  </style>
+
+  <div class="card flex" />
+  ```
+
+<br/>
+
 <details>
   <summary>Common options</summary>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "json-schema": "^0.4.0",
         "markdownlint": "^0.40.0",
         "oxlint": "^1.58.0",
+        "postcss": "^8.5.8",
         "prettier": "^3.8.1",
         "svelte": "^5.55.1",
         "svelte-eslint-parser": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "json-schema": "^0.4.0",
     "markdownlint": "^0.40.0",
     "oxlint": "^1.58.0",
+    "postcss": "^8.5.8",
     "prettier": "^3.8.1",
     "svelte": "^5.55.1",
     "svelte-eslint-parser": "^1.6.0",

--- a/src/parsers/svelte.ts
+++ b/src/parsers/svelte.ts
@@ -18,6 +18,9 @@ import {
 
 import type { Rule } from "eslint";
 import type { BaseNode as ESBaseNode, Node as ESNode } from "estree";
+import type { Rule as PostCSSRule } from "postcss";
+import type { Node as PostCSSSelectorNode } from "postcss-selector-parser";
+import type { parseForESLint } from "svelte-eslint-parser";
 import type {
   SvelteAttachTag,
   SvelteAttribute,
@@ -43,6 +46,9 @@ import type {
 import type { AttributeSelector, MatcherFunctions, SelectorMatcher } from "better-tailwindcss:types/rule.js";
 
 
+type SvelteParserServices = ReturnType<typeof parseForESLint>["services"];
+type ParserServices = Rule.RuleContext["sourceCode"]["parserServices"];
+
 export const SVELTE_CONTAINER_TYPES_TO_REPLACE_QUOTES = [
   ...ES_CONTAINER_TYPES_TO_REPLACE_QUOTES,
   "SvelteMustacheTag"
@@ -50,6 +56,18 @@ export const SVELTE_CONTAINER_TYPES_TO_REPLACE_QUOTES = [
 
 export const SVELTE_CONTAINER_TYPES_TO_INSERT_BRACES: string[] = [
 ];
+
+const SVELTE_STYLE_CLASS_CACHE = new WeakMap<object, Set<string>>();
+
+export type GetSvelteStyleClasses = () => Set<string>;
+
+export let getSvelteStyleClasses: GetSvelteStyleClasses = () => { throw new Error("getSvelteStyleClasses() called before being initialized"); };
+
+export function createGetSvelteStyleClasses(parserServices: ParserServices): GetSvelteStyleClasses {
+  getSvelteStyleClasses = () => collectSvelteStyleClasses(parserServices);
+
+  return getSvelteStyleClasses;
+}
 
 
 export function getAttributesBySvelteTag(ctx: Rule.RuleContext, node: SvelteStartTag): SvelteAttribute[] {
@@ -68,6 +86,46 @@ export function getDirectivesBySvelteTag(ctx: Rule.RuleContext, node: SvelteStar
     }
     return acc;
   }, []);
+}
+
+function collectSvelteStyleClasses(parserServices: ParserServices): Set<string> {
+  if(!isSvelteParserServices(parserServices)){
+    return new Set();
+  }
+
+  const cachedClassNames = SVELTE_STYLE_CLASS_CACHE.get(parserServices);
+
+  if(cachedClassNames){
+    return cachedClassNames;
+  }
+
+  const styleContext = parserServices.getStyleContext();
+
+  if(styleContext.status !== "success"){
+    const result = new Set<string>();
+
+    SVELTE_STYLE_CLASS_CACHE.set(parserServices, result);
+
+    return result;
+  }
+
+  const classNames = new Set<string>();
+
+  styleContext.sourceAst.walkRules((rule: PostCSSRule) => {
+    try {
+      const selectorAst = parserServices.getStyleSelectorAST(rule);
+
+      selectorAst.walk((selectorNode: PostCSSSelectorNode) => {
+        if(selectorNode.type === "class"){
+          classNames.add(selectorNode.value);
+        }
+      });
+    } catch {}
+  });
+
+  SVELTE_STYLE_CLASS_CACHE.set(parserServices, classNames);
+
+  return classNames;
 }
 
 export function getLiteralsBySvelteAttribute(ctx: Rule.RuleContext, attribute: SvelteAttribute, selectors: AttributeSelector[]): Literal[] {
@@ -298,6 +356,10 @@ function isSvelteName(node: ESBaseNode): node is SvelteName {
 function isSvelteMustacheTag(node: ESBaseNode): node is SvelteMustacheTagText {
   return node.type === "SvelteMustacheTag" &&
     "kind" in node && node.kind === "text";
+}
+
+function isSvelteParserServices(parserServices: ParserServices): parserServices is SvelteParserServices {
+  return typeof parserServices?.getStyleContext === "function";
 }
 
 function getSvelteMatcherFunctions(matchers: SelectorMatcher[]): MatcherFunctions {

--- a/src/rules/no-unknown-classes.test.ts
+++ b/src/rules/no-unknown-classes.test.ts
@@ -133,6 +133,202 @@ describe(noUnknownClasses.name, () => {
     );
   });
 
+  it("should still report classes declared in Svelte style blocks by default", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class="local-card" />`,
+
+            errors: 1
+          }
+        ]
+      }
+    );
+  });
+
+  it("should ignore classes declared in Svelte style blocks when configured", () => {
+    lint(
+      noUnknownClasses,
+      {
+        valid: [
+          {
+            svelte: `<style>.local-card { color: red; }:global(.global-card) { color: blue; }</style><div class="local-card global-card flex" />`,
+
+            options: [{ detectSvelteStyleClasses: true }]
+          },
+          {
+            svelte: `<style>.foo\\:bar { color: red; }</style><div class="foo:bar" />`,
+
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should ignore Svelte class directives declared in style blocks when configured", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class:local-card={true} />`,
+
+            errors: 1
+          }
+        ],
+        valid: [
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class:local-card={true} />`,
+
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should ignore all class selectors declared in Svelte style blocks when configured", () => {
+    lint(
+      noUnknownClasses,
+      {
+        valid: [
+          {
+            svelte: `<style>.card .title, .button.primary { color: red; }</style><div class="card title button primary" />`,
+
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should still report unknown classes when the Svelte file has no style block", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            svelte: `<div class="local-card" />`,
+
+            errors: 1,
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not detect Svelte style classes when the style block cannot be parsed", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            svelte: `<style lang="less">.local-card { color: red; }</style><div class="local-card" />`,
+
+            errors: 1,
+            options: [{ detectSvelteStyleClasses: true }]
+          },
+          {
+            svelte: `<style>.local-card {</style><div class="local-card" />`,
+
+            errors: 1,
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should ignore Svelte style rules with selectors that cannot be parsed", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            svelte: `<style>.local-card: { color: red; }.known-card { color: blue; }</style><div class="local-card known-card" />`,
+
+            errors: 1,
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should only ignore exact classes declared in Svelte style blocks", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class="hover:local-card" />`,
+
+            errors: 1,
+            options: [{ detectSvelteStyleClasses: true }]
+          },
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class="local-card typo-card" />`,
+
+            errors: 1,
+            options: [{ detectSvelteStyleClasses: true }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should compose Svelte style classes with ignored classes", () => {
+    lint(
+      noUnknownClasses,
+      {
+        valid: [
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class="local-card ignored-card" />`,
+
+            options: [{
+              detectSvelteStyleClasses: true,
+              ignore: ["^ignored-card$"]
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindCSSVersion().major >= 4)("should compose Svelte style classes with custom component classes in tailwind >= 4", () => {
+    lint(
+      noUnknownClasses,
+      {
+        valid: [
+          {
+            svelte: `<style>.local-card { color: red; }</style><div class="local-card custom-component" />`,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss";
+
+                @layer components {
+                  .custom-component {
+                    @apply font-bold;
+                  }
+                }
+              `
+            },
+            options: [{
+              detectComponentClasses: true,
+              detectSvelteStyleClasses: true,
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
   it("should be possible to whitelist classes in options", () => {
     lint(
       noUnknownClasses,

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -1,5 +1,14 @@
-import { array, description, optional, pipe, strictObject, string } from "valibot";
+import {
+  array,
+  boolean,
+  description,
+  optional,
+  pipe,
+  strictObject,
+  string
+} from "valibot";
 
+import { createGetSvelteStyleClasses, getSvelteStyleClasses } from "better-tailwindcss:parsers/svelte.js";
 import {
   createGetCustomComponentClasses,
   getCustomComponentClasses
@@ -30,6 +39,13 @@ export const noUnknownClasses = createRule({
   },
 
   schema: strictObject({
+    detectSvelteStyleClasses: optional(
+      pipe(
+        boolean(),
+        description("Whether to treat class selectors declared in Svelte style blocks as known classes for that component.")
+      ),
+      false
+    ),
     ignore: optional(
       pipe(
         array(
@@ -42,13 +58,17 @@ export const noUnknownClasses = createRule({
   }),
 
   initialize: ctx => {
-    const { detectComponentClasses } = ctx.options;
+    const { detectComponentClasses, detectSvelteStyleClasses } = ctx.options;
 
     createGetPrefix(ctx);
     createGetUnknownClasses(ctx);
 
     if(detectComponentClasses){
       createGetCustomComponentClasses(ctx);
+    }
+
+    if(detectSvelteStyleClasses){
+      createGetSvelteStyleClasses(ctx.parserServices);
     }
   },
 
@@ -66,6 +86,7 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
   const ignoredPeers = getCachedRegex(`^${escapeForRegex(`${prefix}${suffix}`)}peer(?:\\/(\\S*))?$`);
 
   const customComponentClassRegexes = getCustomComponentClassRegexes(ctx);
+  const svelteStyleClassNames = getSvelteStyleClassNames(ctx);
 
   for(const literal of literals){
 
@@ -86,6 +107,7 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
       if(
         ignore.some(ignoredClass => getCachedRegex(ignoredClass).test(className)) ||
         customComponentClassRegexes?.some(customComponentClassesRegex => customComponentClassesRegex.test(className)) ||
+        svelteStyleClassNames?.has(className) ||
         ignoredGroups.test(className) ||
         ignoredPeers.test(className)
       ){
@@ -115,4 +137,14 @@ function getCustomComponentClassRegexes(ctx: Context<typeof noUnknownClasses>): 
   const { prefix, suffix } = getPrefix(async(ctx));
 
   return customComponentClasses.map(className => getCachedRegex(`^${escapeForRegex(`${prefix}${suffix}`)}(?:.*:)?${escapeForRegex(className)}$`));
+}
+
+function getSvelteStyleClassNames(ctx: Context<typeof noUnknownClasses>): Set<string> | undefined {
+  const { detectSvelteStyleClasses } = ctx.options;
+
+  if(!detectSvelteStyleClasses){
+    return;
+  }
+
+  return getSvelteStyleClasses();
 }

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,4 +1,4 @@
-import type { JSRuleDefinition } from "eslint";
+import type { JSRuleDefinition, Rule } from "eslint";
 import type { BaseIssue, BaseSchema, Default, InferOutput, OptionalSchema, StrictObjectSchema } from "valibot";
 
 import type { CommonOptions } from "better-tailwindcss:options/descriptions.js";
@@ -193,6 +193,8 @@ export interface RuleContext<
   /** The installation path of Tailwind CSS. */
   installation: string;
   options: Options;
+  /** Parser-specific services for the file currently being linted. */
+  parserServices: Rule.RuleContext["sourceCode"]["parserServices"];
   report: <
     const MsgId extends MessageId<Messages>
   >(info:

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -185,6 +185,7 @@ export function createRule<
           docs,
           installation,
           options,
+          parserServices: ctx.sourceCode.parserServices,
           report: ({ fix, range, warnings, ...rest }) => {
             const loc = getLocByRange(ctx, range);
 


### PR DESCRIPTION
Svelte components routinely mix Tailwind utility classes with local component classes declared in the file's `<style>` block. When such a component is linted with `no-unknown-classes`, every local class is flagged as unknown because the rule only knows about Tailwind classes - it has no visibility into the component's scoped styles.

Add an opt-in `detectSvelteStyleClasses` option. When enabled, the rule treats every class selector declared in the component's `<style>` block as known for that file. Style blocks that use an unsupported language or contain malformed CSS silently fall back to detecting nothing, leaving the rule's existing behaviour unchanged for those files.

Previously,

```svelte
<style>
  .card {
    border-radius: 0.5rem;
  }
</style>

<div class="card flex" />
```

would have failed with `Unknown class detected: card`. After this change, with `detectSvelteStyleClasses: true`, it passes.
