### PR TITLE
chore(deps): update tailwind-csstree to v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,10 +3,12 @@
   "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
+  "dev": true,
   "packages": {
     "": {
       "name": "eslint-plugin-better-tailwindcss",
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/css-tree": "^4.0.1",
@@ -14,7 +16,7 @@
         "enhanced-resolve": "^5.20.1",
         "jiti": "^2.6.1",
         "synckit": "^0.11.12",
-        "tailwind-csstree": "^0.3.0",
+        "tailwind-csstree": "^0.3.2",
         "tsconfig-paths-webpack-plugin": "^4.2.0",
         "valibot": "^1.3.1"
       },
@@ -9198,9 +9200,9 @@
       }
     },
     "node_modules/tailwind-csstree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tailwind-csstree/-/tailwind-csstree-0.3.0.tgz",
-      "integrity": "sha512-FJmLCkH1ZDTEqJRVxMVhdiEbk/W67exqvDYrIQ759jsfv3mp3Gp/rrlgtr7dD5q7BK/t8LfaNqXM+BN6BrTKGA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tailwind-csstree/-/tailwind-csstree-0.3.2.tgz",
+      "integrity": "sha512-0iVbtKbzPZG+wcBELC7vK2z1I3n+hUQG3OzyhmMXoJTCm8j5tI+ek2Ch3X/lf/VaTf/yag9mLngoKIaehH6X0g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "enhanced-resolve": "^5.20.1",
     "jiti": "^2.6.1",
     "synckit": "^0.11.12",
-    "tailwind-csstree": "^0.3.0",
+    "tailwind-csstree": "^0.3.2",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "valibot": "^1.3.1"
   },


### PR DESCRIPTION
Close #360 

### Testing
- `npm run test`
-  I have been overriding `tailwind-csstree` to v0.3.2 in my project and have not encountered any issues so far.

### Notes
It might be worth considering `Dependabot` or [`Renovate`](https://docs.renovatebot.com/) to automate dependency updates and reduce maintenance overhead.