### PR TITLE
feat(enforce-consistent-line-wrapping): add `vueConvertToBinding` option

### DIFF
--- a/docs/rules/enforce-consistent-line-wrapping.md
+++ b/docs/rules/enforce-consistent-line-wrapping.md
@@ -83,6 +83,18 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 <br/>
 
+### `vueConvertToBinding`
+
+  When used together with prettier, a static `class` attribute that this rule wraps across multiple lines gets collapsed back onto a single line by prettier, which leads to an [endless conflict](https://github.com/schoero/eslint-plugin-better-tailwindcss/issues/290).  
+  Setting this option to `true` converts the static attribute to a bound attribute with a template literal (`class="…"` → `` :class="`…`" ``) before wrapping, which prettier leaves untouched.
+
+  This option is currently only supported by the vue parser. Existing bindings and classes that already fit on a single line are not changed. If the element already has a binding with the same name (`class="…" :class="…"`), the static attribute is kept and wrapped in place to not create a duplicate attribute.
+
+  **Type**: `boolean`  
+  **Default**: `false`
+
+<br/>
+
 <details>
   <summary>Common options</summary>
 
@@ -202,4 +214,23 @@ The following examples show how the rule behaves with different options:
   focus:font-bold focus:text-opacity-70
   hover:font-bold hover:text-opacity-70
 `} />;
+```
+
+With `vueConvertToBinding: true`, the vue parser converts a static `class` attribute to a bound attribute with a template literal when it wraps, to avoid conflicts with prettier:
+
+```vue
+<!-- ❌ BAD -->
+<template>
+  <img class="absolute top-0 mr-0 mb-0 h-64 -rotate-5 bg-foreground-secondary pt-0 pr-0 opacity-30 blur-sm not-dark:invert" />
+</template>
+```
+
+```vue
+<!-- ✅ GOOD: with { vueConvertToBinding: true } -->
+<template>
+  <img :class="`
+    absolute top-0 mr-0 mb-0 h-64 -rotate-5 bg-foreground-secondary pt-0 pr-0
+    opacity-30 blur-sm not-dark:invert
+  `" />
+</template>
 ```

--- a/src/parsers/vue.test.ts
+++ b/src/parsers/vue.test.ts
@@ -143,6 +143,207 @@ describe("vue", () => {
     });
   });
 
+  it("should convert static classes to bound classes with template literals when vueConvertToBinding is enabled", () => {
+    const singleLine = " a b c d e f g h ";
+    const bound = "`\n  a b c\n  d e f\n  g h\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img class="${singleLine}" /></template>`,
+          vueOutput: `<template><img :class="${bound}" /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        },
+        {
+          vue: `<template><img class='${singleLine}' /></template>`,
+          vueOutput: `<template><img :class='${bound}' /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ],
+      valid: [
+        {
+          vue: `<template><img class="a b" /></template>`,
+
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        },
+        {
+          vue: `<template><img :class="{ 'a b': condition }" /></template>`,
+
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should not convert static classes when vueConvertToBinding is disabled", () => {
+    const singleLine = " a b c d e f g h ";
+    const multipleLines = dedent`
+      a b c
+      d e f
+      g h
+    `;
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img class="${singleLine}" /></template>`,
+          vueOutput: `<template><img class="${multipleLines}" /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2 }]
+        }
+      ]
+    });
+  });
+
+  it("should not report an already converted binding", () => {
+    const bound = "`\n  a b c\n  d e f\n  g h\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      valid: [
+        {
+          vue: `<template><img :class="${bound}" /></template>`,
+
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should wrap an existing template literal binding without adding a binding prefix", () => {
+    const singleLineBound = "`a b c d e f g h`";
+    const bound = "`\n  a b c\n  d e f\n  g h\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img :class="${singleLineBound}" /></template>`,
+          vueOutput: `<template><img :class="${bound}" /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should convert static classes to bound classes when wrapping is triggered by printWidth", () => {
+    const singleLine = "absolute top-0 mr-0 mb-0 h-64 bg-secondary pt-0 pr-0 opacity-30 blur-sm invert flex items-center justify-center";
+    const bound = "`\n  absolute top-0 mr-0 mb-0 h-64 bg-secondary pt-0 pr-0 opacity-30 blur-sm invert\n  flex items-center justify-center\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img class="${singleLine}" /></template>`,
+          vueOutput: `<template><img :class="${bound}" /></template>`,
+
+          errors: 1,
+          options: [{ indent: 2, printWidth: 80, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should not affect sibling attributes when converting", () => {
+    const singleLine = " a b c d e f g h ";
+    const bound = "`\n  a b c\n  d e f\n  g h\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img class="${singleLine}" src="./image.svg" /></template>`,
+          vueOutput: `<template><img :class="${bound}" src="./image.svg" /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should not convert when the element already has a binding with the same name", () => {
+    const singleLine = " a b c d e f g h ";
+    const multipleLines = dedent`
+      a b c
+      d e f
+      g h
+    `;
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img class="${singleLine}" :class="{ active: condition }" /></template>`,
+          vueOutput: `<template><img class="${multipleLines}" :class="{ active: condition }" /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        },
+        {
+          vue: `<template><img class="${singleLine}" v-bind:class="{ active: condition }" /></template>`,
+          vueOutput: `<template><img class="${multipleLines}" v-bind:class="{ active: condition }" /></template>`,
+
+          errors: 1,
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should convert custom matched attributes to their bound name", () => {
+    const singleLine = " a b c d e f g h ";
+    const bound = "`\n  a b c\n  d e f\n  g h\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img myClass="${singleLine}" /></template>`,
+          vueOutput: `<template><img :myClass="${bound}" /></template>`,
+
+          errors: 1,
+          options: [{ attributes: ["myClass"], classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should convert static classes matched by matcher based selectors", () => {
+    const singleLine = " a b c d e f g h ";
+    const bound = "`\n  a b c\n  d e f\n  g h\n`";
+
+    lint(enforceConsistentLineWrapping, {
+      invalid: [
+        {
+          vue: `<template><img myClass="${singleLine}" /></template>`,
+          vueOutput: `<template><img :myClass="${bound}" /></template>`,
+
+          errors: 1,
+          options: [{ attributes: [["myClass", [{ match: MatcherType.String }]]], classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
+  it("should not convert empty or whitespace only attributes", () => {
+    lint(enforceConsistentLineWrapping, {
+      valid: [
+        {
+          vue: `<template><img class="" /></template>`,
+
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        },
+        {
+          vue: `<template><img class="   " /></template>`,
+
+          options: [{ classesPerLine: 3, indent: 2, vueConvertToBinding: true }]
+        }
+      ]
+    });
+  });
+
   // #119
   it("should not report inside member expressions", () => {
     lint(noUnnecessaryWhitespace, {

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -45,7 +45,7 @@ export function getAttributesByVueStartTag(ctx: Rule.RuleContext, node: AST.VSta
   return node.attributes;
 }
 
-export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.VAttribute | AST.VDirective, selectors: AttributeSelector[], options?: { vueConvertToBinding?: boolean; }): Literal[] {
+export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.VAttribute | AST.VDirective, selectors: AttributeSelector[]): Literal[] {
 
   if(attribute.value === null){
     return [];
@@ -54,17 +54,15 @@ export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.
   const name = getVueAttributeName(attribute);
   const value = attribute.value;
 
-  const convertToBinding = options?.vueConvertToBinding === true;
-
   const literals = selectors.reduce<Literal[]>((literals, selector) => {
     if(!matchesName(getVueBoundName(selector.name).toLowerCase(), name?.toLowerCase())){ return literals; }
 
     if(!selector.match){
-      literals.push(...getLiteralsByVueLiteralNode(ctx, value, convertToBinding));
+      literals.push(...getLiteralsByVueLiteralNode(ctx, value));
       return literals;
     }
 
-    literals.push(...getLiteralsByVueMatchers(ctx, value, selector.match, convertToBinding));
+    literals.push(...getLiteralsByVueMatchers(ctx, value, selector.match));
 
     return literals;
   }, []);
@@ -75,12 +73,12 @@ export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.
 
 }
 
-function getLiteralsByVueLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode, convertToBinding: boolean = false): Literal[] {
+function getLiteralsByVueLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode): Literal[] {
 
   if(!hasESNodeParentExtension(node)){ return []; }
 
   if(isVueLiteralNode(node)){
-    const literal = getStringLiteralByVueStringLiteral(ctx, node, convertToBinding);
+    const literal = getStringLiteralByVueStringLiteral(ctx, node);
     return [literal];
   }
 
@@ -92,11 +90,11 @@ function getLiteralsByVueLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode, co
 }
 
 
-function getLiteralsByVueMatchers(ctx: Rule.RuleContext, node: ESBaseNode, matchers: SelectorMatcher[], convertToBinding: boolean = false): Literal[] {
+function getLiteralsByVueMatchers(ctx: Rule.RuleContext, node: ESBaseNode, matchers: SelectorMatcher[]): Literal[] {
   const matcherFunctions = getVueMatcherFunctions(matchers);
 
   const literalNodes = getLiteralNodesByMatchers<ESBaseNode>(ctx, node, matcherFunctions);
-  const literals = literalNodes.flatMap(literalNode => getLiteralsByVueLiteralNode(ctx, literalNode, convertToBinding));
+  const literals = literalNodes.flatMap(literalNode => getLiteralsByVueLiteralNode(ctx, literalNode));
 
   return literals.filter(deduplicateLiterals);
 }
@@ -114,7 +112,7 @@ function getLiteralsByVueESLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode &
   });
 }
 
-function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLiteral, convertToBinding: boolean = false): StringLiteral {
+function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLiteral): StringLiteral {
 
   const raw = ctx.sourceCode.getText(node as unknown as ESNode);
   const line = ctx.sourceCode.lines[node.loc.start.line - 1];
@@ -124,13 +122,13 @@ function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLi
   const whitespaces = getWhitespace(content);
   const indentation = getIndentation(line);
   const multilineQuotes = getMultilineQuotes(node);
-  const binding = convertToBinding ? getBinding(node, quotes, content) : undefined;
+  const binding = getBinding(node, quotes, content);
 
   return {
     ...whitespaces,
     ...quotes,
     ...multilineQuotes,
-    ...binding && { binding, multilineQuotes: ["`"] as LiteralValueQuotes[] },
+    ...binding && { binding },
     content,
     indentation,
     loc: node.loc,
@@ -175,6 +173,7 @@ function getBinding(node: AST.VLiteral, quotes: QuoteMeta, content: string): Bin
 
   return {
     closing: closingQuote,
+    multilineQuotes: ["`"] as LiteralValueQuotes[],
     opening: `:${name}=${openingQuote}`,
     range: [...attribute.range]
   };

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -21,7 +21,14 @@ import type { Rule } from "eslint";
 import type { BaseNode as ESBaseNode, Node as ESNode } from "estree";
 import type { AST } from "vue-eslint-parser";
 
-import type { Literal, LiteralValueQuotes, MultilineMeta, StringLiteral } from "better-tailwindcss:types/ast.js";
+import type {
+  BindingMeta,
+  Literal,
+  LiteralValueQuotes,
+  MultilineMeta,
+  QuoteMeta,
+  StringLiteral
+} from "better-tailwindcss:types/ast.js";
 import type { AttributeSelector, MatcherFunctions, SelectorMatcher } from "better-tailwindcss:types/rule.js";
 
 
@@ -38,7 +45,7 @@ export function getAttributesByVueStartTag(ctx: Rule.RuleContext, node: AST.VSta
   return node.attributes;
 }
 
-export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.VAttribute | AST.VDirective, selectors: AttributeSelector[]): Literal[] {
+export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.VAttribute | AST.VDirective, selectors: AttributeSelector[], options?: { vueConvertToBinding?: boolean; }): Literal[] {
 
   if(attribute.value === null){
     return [];
@@ -47,15 +54,17 @@ export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.
   const name = getVueAttributeName(attribute);
   const value = attribute.value;
 
+  const convertToBinding = options?.vueConvertToBinding === true;
+
   const literals = selectors.reduce<Literal[]>((literals, selector) => {
     if(!matchesName(getVueBoundName(selector.name).toLowerCase(), name?.toLowerCase())){ return literals; }
 
     if(!selector.match){
-      literals.push(...getLiteralsByVueLiteralNode(ctx, value));
+      literals.push(...getLiteralsByVueLiteralNode(ctx, value, convertToBinding));
       return literals;
     }
 
-    literals.push(...getLiteralsByVueMatchers(ctx, value, selector.match));
+    literals.push(...getLiteralsByVueMatchers(ctx, value, selector.match, convertToBinding));
 
     return literals;
   }, []);
@@ -66,12 +75,12 @@ export function getLiteralsByVueAttribute(ctx: Rule.RuleContext, attribute: AST.
 
 }
 
-function getLiteralsByVueLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode): Literal[] {
+function getLiteralsByVueLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode, convertToBinding: boolean = false): Literal[] {
 
   if(!hasESNodeParentExtension(node)){ return []; }
 
   if(isVueLiteralNode(node)){
-    const literal = getStringLiteralByVueStringLiteral(ctx, node);
+    const literal = getStringLiteralByVueStringLiteral(ctx, node, convertToBinding);
     return [literal];
   }
 
@@ -83,11 +92,11 @@ function getLiteralsByVueLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode): L
 }
 
 
-function getLiteralsByVueMatchers(ctx: Rule.RuleContext, node: ESBaseNode, matchers: SelectorMatcher[]): Literal[] {
+function getLiteralsByVueMatchers(ctx: Rule.RuleContext, node: ESBaseNode, matchers: SelectorMatcher[], convertToBinding: boolean = false): Literal[] {
   const matcherFunctions = getVueMatcherFunctions(matchers);
 
   const literalNodes = getLiteralNodesByMatchers<ESBaseNode>(ctx, node, matcherFunctions);
-  const literals = literalNodes.flatMap(literalNode => getLiteralsByVueLiteralNode(ctx, literalNode));
+  const literals = literalNodes.flatMap(literalNode => getLiteralsByVueLiteralNode(ctx, literalNode, convertToBinding));
 
   return literals.filter(deduplicateLiterals);
 }
@@ -105,7 +114,7 @@ function getLiteralsByVueESLiteralNode(ctx: Rule.RuleContext, node: ESBaseNode &
   });
 }
 
-function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLiteral): StringLiteral {
+function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLiteral, convertToBinding: boolean = false): StringLiteral {
 
   const raw = ctx.sourceCode.getText(node as unknown as ESNode);
   const line = ctx.sourceCode.lines[node.loc.start.line - 1];
@@ -115,11 +124,13 @@ function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLi
   const whitespaces = getWhitespace(content);
   const indentation = getIndentation(line);
   const multilineQuotes = getMultilineQuotes(node);
+  const binding = convertToBinding ? getBinding(node, quotes, content) : undefined;
 
   return {
     ...whitespaces,
     ...quotes,
     ...multilineQuotes,
+    ...binding && { binding, multilineQuotes: ["`"] as LiteralValueQuotes[] },
     content,
     indentation,
     loc: node.loc,
@@ -130,6 +141,43 @@ function getStringLiteralByVueStringLiteral(ctx: Rule.RuleContext, node: AST.VLi
     type: "StringLiteral"
   };
 
+}
+
+function getBinding(node: AST.VLiteral, quotes: QuoteMeta, content: string): BindingMeta["binding"] {
+  const attribute = node.parent;
+
+  // nothing to convert for empty or whitespace-only attributes
+  if(content.trim() === ""){
+    return undefined;
+  }
+
+  // only static attributes (`class="…"`) can be converted to a binding
+  if(attribute.type !== "VAttribute" || attribute.directive || attribute.key.type !== "VIdentifier"){
+    return undefined;
+  }
+
+  // skip if the element already has a binding with the same name (`:class` or `v-bind:class`) to not create a duplicate attribute
+  const hasExistingBinding = attribute.parent.attributes.some(sibling => {
+    return sibling.directive &&
+      sibling.key.name.name === "bind" &&
+      sibling.key.argument?.type === "VIdentifier" &&
+      sibling.key.argument.name.toLowerCase() === attribute.key.name.toLowerCase();
+  });
+
+  if(hasExistingBinding){
+    return undefined;
+  }
+
+  // use the raw name to preserve the original casing (the parsed key name is lowercased)
+  const name = attribute.key.rawName;
+  const openingQuote = quotes.openingQuote ?? "\"";
+  const closingQuote = quotes.closingQuote ?? "\"";
+
+  return {
+    closing: closingQuote,
+    opening: `:${name}=${openingQuote}`,
+    range: [...attribute.range]
+  };
 }
 
 function getMultilineQuotes(node: ESBaseNode & Rule.NodeParentExtension | AST.VLiteral): MultilineMeta {

--- a/src/parsers/vue.ts
+++ b/src/parsers/vue.ts
@@ -175,7 +175,7 @@ function getBinding(node: AST.VLiteral, quotes: QuoteMeta, content: string): Bin
     closing: closingQuote,
     multilineQuotes: ["`"] as LiteralValueQuotes[],
     opening: `:${name}=${openingQuote}`,
-    range: [...attribute.range]
+    range: [attribute.range[0], attribute.range[1]]
   };
 }
 

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -130,13 +130,17 @@ export const enforceConsistentLineWrapping = createRule({
 
 
 function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, literals: Literal[]) {
-  const { classesPerLine, group: groupSeparator, messageStyle, preferSingleLine, printWidth, strictness } = ctx.options;
+  const { classesPerLine, group: groupSeparator, messageStyle, preferSingleLine, printWidth, strictness, vueConvertToBinding } = ctx.options;
 
   for(const literal of literals){
 
     if(!literal.supportsMultiline){
       continue;
     }
+
+    // convert a static attribute to a bound attribute if the option is enabled and the parser provided a binding
+    const binding = vueConvertToBinding ? literal.binding : undefined;
+    const multilineQuotes = binding?.multilineQuotes ?? literal.multilineQuotes;
 
     const lineStartPosition = literal.indentation + getIndentation(ctx);
     const literalStartPosition = literal.loc.start.column;
@@ -171,7 +175,7 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
     const groupedClasses = groupClasses(classes, dissectedClasses);
 
     if(literal.openingQuote){
-      if(literal.multilineQuotes?.includes("`")){
+      if(multilineQuotes?.includes("`")){
         multilineClasses.line.addMeta({ openingQuote: "`" });
       } else {
         multilineClasses.line.addMeta({ openingQuote: literal.openingQuote });
@@ -366,7 +370,7 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
       multilineClasses.addLine();
       multilineClasses.line.indent(lineStartPosition - getIndentation(ctx));
 
-      if(literal.multilineQuotes?.includes("`")){
+      if(multilineQuotes?.includes("`")){
         multilineClasses.line.addMeta({ closingQuote: "`" });
       } else {
         multilineClasses.line.addMeta({ closingQuote: literal.closingQuote });
@@ -505,8 +509,8 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
     }
 
     // convert a static attribute to a bound attribute with a template literal, or wrap in place
-    const fix = literal.binding
-      ? `${literal.binding.opening}${fixedClasses}${literal.binding.closing}`
+    const fix = binding
+      ? `${binding.opening}${fixedClasses}${binding.closing}`
       : literal.surroundingBraces
         ? `{${fixedClasses}}`
         : fixedClasses;
@@ -518,7 +522,7 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
       },
       fix,
       id: "missing",
-      range: literal.binding?.range ?? literal.range,
+      range: binding?.range ?? literal.range,
       warnings
     });
 

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -111,6 +111,13 @@ export const enforceConsistentLineWrapping = createRule({
         description("The visual width of a tab character when evaluating printWidth.")
       ),
       1
+    ),
+    vueConvertToBinding: optional(
+      pipe(
+        boolean(),
+        description("Convert static class attributes to bound attributes with template literals when wrapping lines. Currently only supported by the vue parser and useful to avoid conflicts with prettier.")
+      ),
+      false
     )
   }),
 
@@ -497,16 +504,21 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
       continue;
     }
 
+    // convert a static attribute to a bound attribute with a template literal, or wrap in place
+    const fix = literal.binding
+      ? `${literal.binding.opening}${fixedClasses}${literal.binding.closing}`
+      : literal.surroundingBraces
+        ? `{${fixedClasses}}`
+        : fixedClasses;
+
     ctx.report({
       data: {
         notReadable: display(messageStyle, literal.raw),
-        readable: display(messageStyle, fixedClasses)
+        readable: display(messageStyle, fix)
       },
-      fix: literal.surroundingBraces
-        ? `{${fixedClasses}}`
-        : fixedClasses,
+      fix,
       id: "missing",
-      range: literal.range,
+      range: literal.binding?.range ?? literal.range,
       warnings
     });
 

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -40,6 +40,7 @@ export interface BracesMeta {
 export interface BindingMeta {
   binding?: undefined | {
     closing: string;
+    multilineQuotes: LiteralValueQuotes[];
     opening: string;
     range: [number, number];
   };

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -37,6 +37,14 @@ export interface BracesMeta {
   openingBraces?: string | undefined;
 }
 
+export interface BindingMeta {
+  binding?: undefined | {
+    closing: string;
+    opening: string;
+    range: [number, number];
+  };
+}
+
 export interface CSSMeta {
   leadingApply?: string | undefined;
   trailingSemicolon?: string | undefined;
@@ -51,7 +59,7 @@ interface NodeBase extends Range, Loc {
   type: string;
 }
 
-interface LiteralBase extends NodeBase, MultilineMeta, QuoteMeta, BracesMeta, WhitespaceMeta, CSSMeta, Indentation, Range, Loc {
+interface LiteralBase extends NodeBase, MultilineMeta, QuoteMeta, BracesMeta, BindingMeta, WhitespaceMeta, CSSMeta, Indentation, Range, Loc {
   content: string;
   raw: string;
   attribute?: string | undefined;

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -377,7 +377,7 @@ export function createRuleListener<Ctx extends Context>(ctx: Rule.RuleContext, c
       const vueAttributes = getAttributesByVueStartTag(ctx, vueNode);
 
       for(const attribute of vueAttributes){
-        const literals = getLiteralsByVueAttribute(ctx, attribute, attributes);
+        const literals = getLiteralsByVueAttribute(ctx, attribute, attributes, context.options);
 
         if(literals.length > 0){
           lintLiterals(context, literals);

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -377,7 +377,7 @@ export function createRuleListener<Ctx extends Context>(ctx: Rule.RuleContext, c
       const vueAttributes = getAttributesByVueStartTag(ctx, vueNode);
 
       for(const attribute of vueAttributes){
-        const literals = getLiteralsByVueAttribute(ctx, attribute, attributes, context.options);
+        const literals = getLiteralsByVueAttribute(ctx, attribute, attributes);
 
         if(literals.length > 0){
           lintLiterals(context, literals);


### PR DESCRIPTION
Adds a new `vueConvertToBinding` option to [enforce-consistent-line-wrapping](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-consistent-line-wrapping.md).

When this rule wraps a static `class` attribute in a vue template, prettier collapses it back onto a single line, causing an endless conflict between the two tools. With this option enabled, the static attribute is converted to a bound attribute with a template literal instead, which prettier leaves untouched:

```vue
<!-- before -->
<img class="absolute top-0 mr-0 mb-0 h-64 -rotate-5 bg-foreground-secondary pt-0 pr-0 opacity-30 blur-sm not-dark:invert" />

<!-- after -->
<img :class="`
  absolute top-0 mr-0 mb-0 h-64 -rotate-5 bg-foreground-secondary pt-0 pr-0
  opacity-30 blur-sm not-dark:invert
`" />
```

The implementation is kept generic: the vue parser attaches an optional `binding` meta to the extracted literal, and the rule only consumes that meta when building the fix. The rule itself has no knowledge of vue.

The conversion is skipped whenever it wouldn't be safe or useful: existing bindings and directives, empty attributes, classes that already fit on a single line, and elements that already have a binding with the same name (`class="…" :class="…"`), where converting would create a duplicate attribute. In that case the static attribute is wrapped in place instead.

closes: #290