### PR TITLE
feat: no concatenated classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 
 | Name | Description | `tw3` | `tw4` | `recommended` | autofix |
 | :--- | :--- | :---: | :---: | :---: | :---: |
+| [no-concatenated-classes](docs/rules/no-concatenated-classes.md) | Disallow concatenated classes in Tailwind CSS class strings. | ✔ | ✔ | ✔ |  |
 | [no-unknown-classes](docs/rules/no-unknown-classes.md) | Report classes not registered with Tailwind CSS. | ✔ | ✔ | ✔ |  |
 | [no-conflicting-classes](docs/rules/no-conflicting-classes.md) | Report classes that produce conflicting styles. |  | ✔ | ✔ |  |
 | [no-restricted-classes](docs/rules/no-restricted-classes.md) | Disallow restricted classes. | ✔ | ✔ |  | ✔ |

--- a/docs/rules/no-concatenated-classes.md
+++ b/docs/rules/no-concatenated-classes.md
@@ -1,0 +1,25 @@
+# better-tailwindcss/no-concatenated-classes
+
+Disallow concatenated Tailwind CSS classes in class strings.
+
+Concatenated or interpolated class names can be missed by Tailwind's class detection and may be purged from the final CSS output.
+See the [Tailwind documentation](https://tailwindcss.com/docs/detecting-classes-in-source-files).
+
+<br/>
+
+## Examples
+
+```text
+// ❌ BAD: class name built dynamically via concatenation
+<div className={"bg-" + color} />;
+```
+
+```tsx
+// ❌ BAD: class name built dynamically via interpolation
+<div className={`bg-${color}`} />;
+```
+
+```tsx
+// ✅ GOOD: class name is fully static and detectable
+<div className="bg-red-500 text-white" />;
+```

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -6,6 +6,7 @@ import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules/enforc
 import { enforceConsistentVariantOrder } from "better-tailwindcss:rules/enforce-consistent-variant-order.js";
 import { enforceLogicalProperties } from "better-tailwindcss:rules/enforce-logical-properties.js";
 import { enforceShorthandClasses } from "better-tailwindcss:rules/enforce-shorthand-classes.js";
+import { noConcatenatedClasses } from "better-tailwindcss:rules/no-concatenated-classes.js";
 import { noConflictingClasses } from "better-tailwindcss:rules/no-conflicting-classes.js";
 import { noDeprecatedClasses } from "better-tailwindcss:rules/no-deprecated-classes.js";
 import { noDuplicateClasses } from "better-tailwindcss:rules/no-duplicate-classes.js";
@@ -42,6 +43,7 @@ const rules = [
   enforceConsistentVariableSyntax,
   enforceLogicalProperties,
   enforceShorthandClasses,
+  noConcatenatedClasses,
   noConflictingClasses,
   noDeprecatedClasses,
   noDuplicateClasses,

--- a/src/rules/no-concatenated-classes.test.ts
+++ b/src/rules/no-concatenated-classes.test.ts
@@ -17,6 +17,24 @@ describe(noConcatenatedClasses.name, () => {
           vue: `<template><img :class="'bg-' + color" /></template>`,
 
           errors: 1
+        },
+        {
+          angular: `<img [class]="color + '-500'" />`,
+          astro: `<img class={color + "-500"} />`,
+          jsx: `() => <img className={color + "-500"} />`,
+          svelte: `<img class={color + "-500"} />`,
+          vue: `<template><img :class="color + '-500'" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img [class]="'bg-' + color + '-500'" />`,
+          astro: `<img class={"bg-" + color + "-500"} />`,
+          jsx: `() => <img className={"bg-" + color + "-500"} />`,
+          svelte: `<img class={"bg-" + color + "-500"} />`,
+          vue: `<template><img :class="'bg-' + color + '-500'" /></template>`,
+
+          errors: 2
         }
       ]
     });
@@ -33,6 +51,24 @@ describe(noConcatenatedClasses.name, () => {
           vue: `<template><img :class="\`bg-\${color}\`" /></template>`,
 
           errors: 1
+        },
+        {
+          angular: `<img [class]="\`\${color}-500\`" />`,
+          astro: `<img class={\`\${color}-500\`} />`,
+          jsx: `() => <img className={\`\${color}-500\`} />`,
+          svelte: `<img class={\`\${color}-500\`} />`,
+          vue: `<template><img :class="\`\${color}-500\`" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img [class]="\`bg-\${color}-500\`" />`,
+          astro: `<img class={\`bg-\${color}-500\`} />`,
+          jsx: `() => <img className={\`bg-\${color}-500\`} />`,
+          svelte: `<img class={\`bg-\${color}-500\`} />`,
+          vue: `<template><img :class="\`bg-\${color}-500\`" /></template>`,
+
+          errors: 2
         }
       ]
     });

--- a/src/rules/no-concatenated-classes.test.ts
+++ b/src/rules/no-concatenated-classes.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "vitest";
+
+import { noConcatenatedClasses } from "better-tailwindcss:rules/no-concatenated-classes.js";
+import { lint } from "better-tailwindcss:tests/utils/lint.js";
+
+
+describe(noConcatenatedClasses.name, () => {
+
+  it("should report classes concatenated with plus operator", () => {
+    lint(noConcatenatedClasses, {
+      invalid: [
+        {
+          angular: `<img [class]="'bg-' + color" />`,
+          astro: `<img class={"bg-" + color} />`,
+          jsx: `() => <img className={"bg-" + color} />`,
+          svelte: `<img class={"bg-" + color} />`,
+          vue: `<template><img :class="'bg-' + color" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should report interpolated class strings", () => {
+    lint(noConcatenatedClasses, {
+      invalid: [
+        {
+          angular: `<img [class]="\`bg-\${color}\`" />`,
+          astro: `<img class={\`bg-\${color}\`} />`,
+          jsx: `() => <img className={\`bg-\${color}\`} />`,
+          svelte: `<img class={\`bg-\${color}\`} />`,
+          vue: `<template><img :class="\`bg-\${color}\`" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should not report static class strings", () => {
+    lint(noConcatenatedClasses, {
+      valid: [
+        {
+          angular: `<img class="bg-red-500 text-white" />`,
+          astro: `<img class="bg-red-500 text-white" />`,
+          html: `<img class="bg-red-500 text-white" />`,
+          jsx: `() => <img className="bg-red-500 text-white" />`,
+          svelte: `<img class="bg-red-500 text-white" />`,
+          vue: `<template><img class="bg-red-500 text-white" /></template>`,
+
+          css: `a { @apply bg-red-500 text-white; }`
+        }
+      ]
+    });
+  });
+});

--- a/src/rules/no-concatenated-classes.test.ts
+++ b/src/rules/no-concatenated-classes.test.ts
@@ -6,6 +6,23 @@ import { lint } from "better-tailwindcss:tests/utils/lint.js";
 
 describe(noConcatenatedClasses.name, () => {
 
+  it("should not report static class strings", () => {
+    lint(noConcatenatedClasses, {
+      valid: [
+        {
+          angular: `<img class="bg-red-500 text-white" />`,
+          astro: `<img class="bg-red-500 text-white" />`,
+          html: `<img class="bg-red-500 text-white" />`,
+          jsx: `() => <img className="bg-red-500 text-white" />`,
+          svelte: `<img class="bg-red-500 text-white" />`,
+          vue: `<template><img class="bg-red-500 text-white" /></template>`,
+
+          css: `a { @apply bg-red-500 text-white; }`
+        }
+      ]
+    });
+  });
+
   it("should report classes concatenated with plus operator", () => {
     lint(noConcatenatedClasses, {
       invalid: [
@@ -90,20 +107,103 @@ describe(noConcatenatedClasses.name, () => {
     });
   });
 
-  it("should not report static class strings", () => {
+  it("should not report interpolation separated from classes by whitespace", () => {
     lint(noConcatenatedClasses, {
       valid: [
         {
-          angular: `<img class="bg-red-500 text-white" />`,
-          astro: `<img class="bg-red-500 text-white" />`,
-          html: `<img class="bg-red-500 text-white" />`,
-          jsx: `() => <img className="bg-red-500 text-white" />`,
-          svelte: `<img class="bg-red-500 text-white" />`,
-          vue: `<template><img class="bg-red-500 text-white" /></template>`,
-
-          css: `a { @apply bg-red-500 text-white; }`
+          angular: `<img [class]="\`bg-red-500 \${color}\`" />`,
+          astro: `<img class={\`bg-red-500 \${color}\`} />`,
+          jsx: `() => <img className={\`bg-red-500 \${color}\`} />`,
+          svelte: `<img class={\`bg-red-500 \${color}\`} />`,
+          vue: `<template><img :class="\`bg-red-500 \${color}\`" /></template>`
+        },
+        {
+          angular: `<img [class]="\`\${color} bg-red-500\`" />`,
+          astro: `<img class={\`\${color} bg-red-500\`} />`,
+          jsx: `() => <img className={\`\${color} bg-red-500\`} />`,
+          svelte: `<img class={\`\${color} bg-red-500\`} />`,
+          vue: `<template><img :class="\`\${color} bg-red-500\`" /></template>`
         }
       ]
     });
   });
+
+  it("should report multiple interpolations in one class string", () => {
+    lint(noConcatenatedClasses, {
+      invalid: [
+        {
+          angular: `<img [class]="\`bg-\${color}-\${shade}-500\`" />`,
+          astro: `<img class={\`bg-\${color}-\${shade}-500\`} />`,
+          jsx: `() => <img className={\`bg-\${color}-\${shade}-500\`} />`,
+          svelte: `<img class={\`bg-\${color}-\${shade}-500\`} />`,
+          vue: `<template><img :class="\`bg-\${color}-\${shade}-500\`" /></template>`,
+
+          errors: 3
+        }
+      ]
+    });
+  });
+
+  it("should not report templates without static class fragments", () => {
+    lint(noConcatenatedClasses, {
+      valid: [
+        {
+          angular: `<img [class]="\`\${color}\`" />`,
+          astro: `<img class={\`\${color}\`} />`,
+          jsx: `() => <img className={\`\${color}\`} />`,
+          svelte: `<img class={\`\${color}\`} />`,
+          vue: `<template><img :class="\`\${color}\`" /></template>`
+        },
+        {
+          angular: `<img [class]="\`\${color}\${shade}\`" />`,
+          astro: `<img class={\`\${color}\${shade}\`} />`,
+          jsx: `() => <img className={\`\${color}\${shade}\`} />`,
+          svelte: `<img class={\`\${color}\${shade}\`} />`,
+          vue: `<template><img :class="\`\${color}\${shade}\`" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report interpolated class fragments with outer whitespace", () => {
+    lint(noConcatenatedClasses, {
+      invalid: [
+        {
+          angular: `<img [class]="\` bg-\${color} \`" />`,
+          astro: `<img class={\` bg-\${color} \`} />`,
+          jsx: `() => <img className={\` bg-\${color} \`} />`,
+          svelte: `<img class={\` bg-\${color} \`} />`,
+          vue: `<template><img :class="\` bg-\${color} \`" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img [class]="\` \${color}-500  \`" />`,
+          astro: `<img class={\` \${color}-500  \`} />`,
+          jsx: `() => <img className={\` \${color}-500  \`} />`,
+          svelte: `<img class={\` \${color}-500  \`} />`,
+          vue: `<template><img :class="\` \${color}-500  \`" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should report mixed plus and template concatenation", () => {
+    lint(noConcatenatedClasses, {
+      invalid: [
+        {
+          angular: `<img [class]="\`bg-\${color}\` + '-500'" />`,
+          astro: `<img class={"bg-" + \`\${color}\` + "-500"} />`,
+          jsx: `() => <img className={"bg-" + \`\${color}\` + "-500"} />`,
+          svelte: `<img class={"bg-" + \`\${color}\` + "-500"} />`,
+          vue: `<template><img :class="'bg-' + \`\${color}\` + '-500'" /></template>`,
+
+          errors: 2
+        }
+      ]
+    });
+  });
+
 });

--- a/src/rules/no-concatenated-classes.test.ts
+++ b/src/rules/no-concatenated-classes.test.ts
@@ -38,6 +38,22 @@ describe(noConcatenatedClasses.name, () => {
     });
   });
 
+  it("should only report the edge classes that are actually concatenated", () => {
+    lint(noConcatenatedClasses, {
+      invalid: [
+        {
+          angular: `<img [class]="'static bg-' + color + ' text-white trailing'" />`,
+          astro: `<img class={"static bg-" + color + " text-white trailing"} />`,
+          jsx: `() => <img className={"static bg-" + color + " text-white trailing"} />`,
+          svelte: `<img class={"static bg-" + color + " text-white trailing"} />`,
+          vue: `<template><img :class="'static bg-' + color + ' text-white trailing'" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
   it("should not report static class strings", () => {
     lint(noConcatenatedClasses, {
       valid: [

--- a/src/rules/no-concatenated-classes.ts
+++ b/src/rules/no-concatenated-classes.ts
@@ -1,5 +1,6 @@
+import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { createRule } from "better-tailwindcss:utils/rule.js";
-import { isConcatenatedLiteral } from "better-tailwindcss:utils/utils.js";
+import { isConcatenatedClass, isConcatenatedLiteral } from "better-tailwindcss:utils/utils.js";
 
 import type { Literal } from "better-tailwindcss:types/ast.js";
 import type { Context } from "better-tailwindcss:types/rule.js";
@@ -14,7 +15,7 @@ export const noConcatenatedClasses = createRule({
   recommended: true,
 
   messages: {
-    concatenated: "Concatenated classes may be purged by Tailwind CSS. Avoid dynamic class construction: https://tailwindcss.com/docs/detecting-classes-in-source-files"
+    concatenated: "Concatenated classes may be purged by Tailwind CSS. Avoid dynamic class construction."
   },
 
   lintLiterals: (ctx, literals) => lintLiterals(ctx, literals)
@@ -27,9 +28,14 @@ function lintLiterals(ctx: Context<typeof noConcatenatedClasses>, literals: Lite
       continue;
     }
 
-    ctx.report({
-      id: "concatenated",
-      range: literal.range
+    lintClasses(ctx, literal, (_, index) => {
+      if(!isConcatenatedClass(literal, index)){
+        return;
+      }
+
+      return {
+        id: "concatenated"
+      } as const;
     });
   }
 }

--- a/src/rules/no-concatenated-classes.ts
+++ b/src/rules/no-concatenated-classes.ts
@@ -1,4 +1,5 @@
 import { createRule } from "better-tailwindcss:utils/rule.js";
+import { isConcatenatedLiteral } from "better-tailwindcss:utils/utils.js";
 
 import type { Literal } from "better-tailwindcss:types/ast.js";
 import type { Context } from "better-tailwindcss:types/rule.js";
@@ -31,16 +32,4 @@ function lintLiterals(ctx: Context<typeof noConcatenatedClasses>, literals: Lite
       range: literal.range
     });
   }
-}
-
-function isConcatenatedLiteral(literal: Literal) {
-  const isTemplateInterpolation =
-    literal.isInterpolated === true &&
-    literal.openingBraces !== undefined;
-
-  const isStringConcatenation =
-    literal.isConcatenatedLeft === true ||
-    literal.isConcatenatedRight === true;
-
-  return isTemplateInterpolation || isStringConcatenation;
 }

--- a/src/rules/no-concatenated-classes.ts
+++ b/src/rules/no-concatenated-classes.ts
@@ -1,0 +1,46 @@
+import { createRule } from "better-tailwindcss:utils/rule.js";
+
+import type { Literal } from "better-tailwindcss:types/ast.js";
+import type { Context } from "better-tailwindcss:types/rule.js";
+
+
+export const noConcatenatedClasses = createRule({
+  autofix: false,
+  category: "correctness",
+  description: "Disallow concatenated classes in Tailwind CSS class strings.",
+  docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/no-concatenated-classes.md",
+  name: "no-concatenated-classes",
+  recommended: true,
+
+  messages: {
+    concatenated: "Concatenated classes may be purged by Tailwind CSS. Avoid dynamic class construction: https://tailwindcss.com/docs/detecting-classes-in-source-files"
+  },
+
+  lintLiterals: (ctx, literals) => lintLiterals(ctx, literals)
+});
+
+
+function lintLiterals(ctx: Context<typeof noConcatenatedClasses>, literals: Literal[]) {
+  for(const literal of literals){
+    if(!isConcatenatedLiteral(literal)){
+      continue;
+    }
+
+    ctx.report({
+      id: "concatenated",
+      range: literal.range
+    });
+  }
+}
+
+function isConcatenatedLiteral(literal: Literal) {
+  const isTemplateInterpolation =
+    literal.isInterpolated === true &&
+    literal.openingBraces !== undefined;
+
+  const isStringConcatenation =
+    literal.isConcatenatedLeft === true ||
+    literal.isConcatenatedRight === true;
+
+  return isTemplateInterpolation || isStringConcatenation;
+}

--- a/src/rules/no-unknown-classes.test.ts
+++ b/src/rules/no-unknown-classes.test.ts
@@ -167,6 +167,25 @@ describe(noUnknownClasses.name, () => {
     );
   });
 
+  it("should only ignore unknown classes that are actually concatenated", () => {
+    lint(
+      noUnknownClasses,
+      {
+        invalid: [
+          {
+            angular: `<img [class]="'bg-' + color + ' unknown'" />`,
+            astro: `<img class={"bg-" + color + " unknown"} />`,
+            jsx: `() => <img className={"bg-" + color + " unknown"} />`,
+            svelte: `<img class={"bg-" + color + " unknown"} />`,
+            vue: `<template><img :class="'bg-' + color + ' unknown'" /></template>`,
+
+            errors: 1
+          }
+        ]
+      }
+    );
+  });
+
   it("should be possible to whitelist classes in options", () => {
     lint(
       noUnknownClasses,

--- a/src/rules/no-unknown-classes.test.ts
+++ b/src/rules/no-unknown-classes.test.ts
@@ -133,6 +133,40 @@ describe(noUnknownClasses.name, () => {
     );
   });
 
+  it("should ignore classes concatenated with plus operator", () => {
+    lint(
+      noUnknownClasses,
+      {
+        valid: [
+          {
+            angular: `<img [class]="'bg-' + color" />`,
+            astro: `<img class={"bg-" + color} />`,
+            jsx: `() => <img className={"bg-" + color} />`,
+            svelte: `<img class={"bg-" + color} />`,
+            vue: `<template><img :class="'bg-' + color" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should ignore interpolated class strings", () => {
+    lint(
+      noUnknownClasses,
+      {
+        valid: [
+          {
+            angular: `<img [class]="\`bg-\${color}\`" />`,
+            astro: `<img class={\`bg-\${color}\`} />`,
+            jsx: `() => <img className={\`bg-\${color}\`} />`,
+            svelte: `<img class={\`bg-\${color}\`} />`,
+            vue: `<template><img :class="\`bg-\${color}\`" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
   it("should be possible to whitelist classes in options", () => {
     lint(
       noUnknownClasses,

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -11,7 +11,7 @@ import { escapeForRegex } from "better-tailwindcss:utils/escape.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCachedRegex } from "better-tailwindcss:utils/regex.js";
 import { createRule } from "better-tailwindcss:utils/rule.js";
-import { splitClasses } from "better-tailwindcss:utils/utils.js";
+import { isConcatenatedLiteral, splitClasses } from "better-tailwindcss:utils/utils.js";
 
 import type { Literal } from "better-tailwindcss:types/ast.js";
 import type { Context } from "better-tailwindcss:types/rule.js";
@@ -68,6 +68,10 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
   const customComponentClassRegexes = getCustomComponentClassRegexes(ctx);
 
   for(const literal of literals){
+
+    if(isConcatenatedLiteral(literal)){
+      continue;
+    }
 
     const classes = splitClasses(literal.content);
 

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -11,7 +11,7 @@ import { escapeForRegex } from "better-tailwindcss:utils/escape.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCachedRegex } from "better-tailwindcss:utils/regex.js";
 import { createRule } from "better-tailwindcss:utils/rule.js";
-import { isConcatenatedLiteral, splitClasses } from "better-tailwindcss:utils/utils.js";
+import { isConcatenatedClass, splitClasses } from "better-tailwindcss:utils/utils.js";
 
 import type { Literal } from "better-tailwindcss:types/ast.js";
 import type { Context } from "better-tailwindcss:types/rule.js";
@@ -68,11 +68,6 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
   const customComponentClassRegexes = getCustomComponentClassRegexes(ctx);
 
   for(const literal of literals){
-
-    if(isConcatenatedLiteral(literal)){
-      continue;
-    }
-
     const classes = splitClasses(literal.content);
 
     const { unknownClasses, warnings } = getUnknownClasses(async(ctx), classes);
@@ -81,7 +76,11 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
       continue;
     }
 
-    lintClasses(ctx, literal, className => {
+    lintClasses(ctx, literal, (className, classIndex) => {
+
+      if(isConcatenatedClass(literal, classIndex)){
+        return;
+      }
 
       if(!unknownClasses.includes(className)){
         return;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -120,6 +120,36 @@ export function isClassSticky(literal: Literal, classIndex: number): boolean {
   );
 }
 
+export function isConcatenatedClass(literal: Literal, classIndex: number): boolean {
+  if(!isConcatenatedLiteral(literal)){
+    return false;
+  }
+
+  const classes = literal.content;
+
+  const classChunks = splitClasses(classes);
+  const whitespaceChunks = splitWhitespaces(classes);
+
+  const startsWithWhitespace = whitespaceChunks.length > 0 && whitespaceChunks[0] !== "";
+  const endsWithWhitespace = whitespaceChunks.length > 0 && whitespaceChunks[whitespaceChunks.length - 1] !== "";
+
+  const isFirstClass = classIndex === 0;
+  const isLastClass = classIndex === classChunks.length - 1;
+
+  const isConcatenatedOnLeft =
+    literal.isConcatenatedLeft === true ||
+    literal.closingBraces !== undefined;
+
+  const isConcatenatedOnRight =
+    literal.isConcatenatedRight === true ||
+    literal.openingBraces !== undefined;
+
+  return (
+    !startsWithWhitespace && isFirstClass && isConcatenatedOnLeft ||
+    !endsWithWhitespace && isLastClass && isConcatenatedOnRight
+  );
+}
+
 export function isConcatenatedLiteral(literal: Literal) {
   const isTemplateInterpolation =
     literal.isInterpolated === true &&

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -153,7 +153,10 @@ export function isConcatenatedClass(literal: Literal, classIndex: number): boole
 export function isConcatenatedLiteral(literal: Literal) {
   const isTemplateInterpolation =
     literal.isInterpolated === true &&
-    literal.openingBraces !== undefined;
+    (
+      literal.openingBraces !== undefined ||
+      literal.closingBraces !== undefined
+    );
 
   const isStringConcatenation =
     literal.isConcatenatedLeft === true ||

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -120,6 +120,18 @@ export function isClassSticky(literal: Literal, classIndex: number): boolean {
   );
 }
 
+export function isConcatenatedLiteral(literal: Literal) {
+  const isTemplateInterpolation =
+    literal.isInterpolated === true &&
+    literal.openingBraces !== undefined;
+
+  const isStringConcatenation =
+    literal.isConcatenatedLeft === true ||
+    literal.isConcatenatedRight === true;
+
+  return isTemplateInterpolation || isStringConcatenation;
+}
+
 export function getExactClassLocation(literal: Literal, startIndex: number, endIndex: number) {
   const linesUpToStartIndex = literal.content.slice(0, startIndex).split(/\r?\n/);
   const isOnFirstLine = linesUpToStartIndex.length === 1;


### PR DESCRIPTION
This pull request introduces a new rule, `no-concatenated-classes`, which disallows the use of concatenated or interpolated Tailwind CSS class strings to prevent issues with class detection and purging. 

The rule is added to the recommended rules.
Additionally, the `no-unknown-classes` rule is updated to ignore concatenated classes, ensuring it does not report false positives on dynamic class names.

```tsx
const color = "red";

<div class={`bg-${color}`} />
             ~~~
<div class={"bg-" + color} />
             ~~~
```