### PR TITLE
feat: enforce motion safe variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | [no-unknown-classes](docs/rules/no-unknown-classes.md) | Report classes not registered with Tailwind CSS. | ✔ | ✔ | ✔ |  |
 | [no-conflicting-classes](docs/rules/no-conflicting-classes.md) | Report classes that produce conflicting styles. |  | ✔ | ✔ |  |
 | [no-restricted-classes](docs/rules/no-restricted-classes.md) | Disallow restricted classes. | ✔ | ✔ |  | ✔ |
+| [enforce-motion-safe-variant](docs/rules/enforce-motion-safe-variant.md) | Enforce the 'motion-safe' variant for transition and animation classes. | ✔ | ✔ |  |  |
 
 <br/>
 <br/>

--- a/docs/rules/enforce-motion-safe-variant.md
+++ b/docs/rules/enforce-motion-safe-variant.md
@@ -1,0 +1,122 @@
+# better-tailwindcss/enforce-motion-safe-variant
+
+Enforce the `motion-safe` variant for transition and animation classes. This rule helps ensure that motion-related CSS classes are properly wrapped with the `motion-safe` variant to respect user preferences for reduced motion.
+
+Users who prefer reduced motion may have their browser or operating system configured to minimize unnecessary animations. By requiring the `motion-safe` variant, you ensure that transition and animation classes only apply when the user has not expressed a preference for reduced motion.
+
+<br/>
+
+## Options
+
+### `allowMotionReduce`
+
+Suppress warnings for a literal that already contains a class with the `motion-reduce` variant. This allows you to handle motion-related effects either with `motion-safe` or `motion-reduce`.
+
+**Type**: `boolean`  
+**Default**: `false`
+
+<br/>
+
+### `classes`
+
+A list of regular expression patterns for classes that require the `motion-safe` variant. This allows you to customize which classes trigger this rule.
+
+**Type**: `string[]`  
+**Default**: `["^transition(-.*)?$", "^animate(-.*)?$"]`
+
+<br/>
+
+<details>
+  <summary>Common options</summary>
+
+  <br/>
+
+  These options are common to all rules and can also be set globally via the [`settings` object](../settings/settings.md).
+
+  <br/>
+
+### `selectors`
+
+  Flat list of selectors that determines where Tailwind class strings are linted.
+
+  **Type**: Array of [Selectors](../configuration/advanced.md#selectors)
+  **Default**: See [defaults API](../api/defaults.md)
+
+  <br/>
+
+### `entryPoint`
+
+  The path to the entry file of the css based tailwind config (eg: `src/global.css`).  
+  If not specified, the plugin will fall back to the default configuration.  
+
+  **Type**: `string`  
+  **Default**: `undefined`
+
+  <br/>
+
+### `tailwindConfig`
+
+  The path to the `tailwind.config.js` file. If not specified, the plugin will try to find it automatically or falls back to the default configuration.  
+  This can also be set globally via the [`settings` object](../settings/settings.md#tailwindConfig).  
+
+  For Tailwind CSS v4 and the css based config, use the [`entryPoint`](#entrypoint) option instead.
+
+  **Type**: `string`  
+  **Default**: `undefined`
+
+<br/>
+
+### `tsconfig`
+
+  The path to the `tsconfig.json` file. If not specified, the plugin will try to find it automatically.  
+  This can also be set globally via the [`settings` object](../settings/settings.md#tsconfig).  
+
+  The tsconfig is used to resolve tsconfig [`path`](https://www.typescriptlang.org/tsconfig/#paths) aliases.
+
+  **Type**: `string`  
+  **Default**: `undefined`
+
+</details>
+
+<br/>
+
+## Examples
+
+### Missing motion-safe variant
+
+```tsx
+// ❌ BAD
+<div class="transition-colors"></div>
+<div class="animate-spin"></div>
+```
+
+```tsx
+// ✅ GOOD
+<div class="motion-safe:transition-colors"></div>
+<div class="motion-safe:animate-spin"></div>
+```
+
+### With other variants
+
+```tsx
+// ❌ BAD: motion-safe is missing
+<div class="hover:transition-colors"></div>
+<div class="dark:animate-spin"></div>
+```
+
+```tsx
+// ✅ GOOD: motion-safe can be combined with other variants
+<div class="dark:motion-safe:transition-colors"></div>
+<div class="motion-safe:hover:animate-spin"></div>
+<div class="lg:dark:motion-safe:transition-all"></div>
+```
+
+### Using motion-reduce alternative
+
+```tsx
+// ✅ GOOD: with option { "allowMotionReduce": true }
+<div class="motion-reduce:transition-none transition-all"></div>
+<div class="motion-reduce:animate-none animate-spin"></div>
+```
+
+In this case, the rule allows motion classes without the `motion-safe` variant because `motion-reduce` is present, providing an explicit alternative for users who prefer reduced motion.

--- a/docs/rules/enforce-motion-safe-variant.md
+++ b/docs/rules/enforce-motion-safe-variant.md
@@ -84,13 +84,13 @@ A list of regular expression patterns for classes that require the `motion-safe`
 
 ### Missing motion-safe variant
 
-```tsx
+```html
 // ❌ BAD
 <div class="transition-colors"></div>
 <div class="animate-spin"></div>
 ```
 
-```tsx
+```html
 // ✅ GOOD
 <div class="motion-safe:transition-colors"></div>
 <div class="motion-safe:animate-spin"></div>
@@ -98,13 +98,13 @@ A list of regular expression patterns for classes that require the `motion-safe`
 
 ### With other variants
 
-```tsx
+```html
 // ❌ BAD: motion-safe is missing
 <div class="hover:transition-colors"></div>
 <div class="dark:animate-spin"></div>
 ```
 
-```tsx
+```html
 // ✅ GOOD: motion-safe can be combined with other variants
 <div class="dark:motion-safe:transition-colors"></div>
 <div class="motion-safe:hover:animate-spin"></div>
@@ -113,7 +113,7 @@ A list of regular expression patterns for classes that require the `motion-safe`
 
 ### Using motion-reduce alternative
 
-```tsx
+```html
 // ✅ GOOD: with option { "allowMotionReduce": true }
 <div class="motion-reduce:transition-none transition-all"></div>
 <div class="motion-reduce:animate-none animate-spin"></div>

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -5,6 +5,7 @@ import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-
 import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules/enforce-consistent-variable-syntax.js";
 import { enforceConsistentVariantOrder } from "better-tailwindcss:rules/enforce-consistent-variant-order.js";
 import { enforceLogicalProperties } from "better-tailwindcss:rules/enforce-logical-properties.js";
+import { enforceMotionSafeVariant } from "better-tailwindcss:rules/enforce-motion-safe-variant.js";
 import { enforceShorthandClasses } from "better-tailwindcss:rules/enforce-shorthand-classes.js";
 import { noConflictingClasses } from "better-tailwindcss:rules/no-conflicting-classes.js";
 import { noDeprecatedClasses } from "better-tailwindcss:rules/no-deprecated-classes.js";
@@ -41,6 +42,7 @@ const rules = [
   enforceConsistentVariantOrder,
   enforceConsistentVariableSyntax,
   enforceLogicalProperties,
+  enforceMotionSafeVariant,
   enforceShorthandClasses,
   noConflictingClasses,
   noDeprecatedClasses,

--- a/src/rules/enforce-motion-safe-variant.test.ts
+++ b/src/rules/enforce-motion-safe-variant.test.ts
@@ -1,0 +1,372 @@
+import { describe, it } from "vitest";
+
+import { enforceMotionSafeVariant } from "better-tailwindcss:rules/enforce-motion-safe-variant.js";
+import { lint } from "better-tailwindcss:tests/utils/lint.js";
+import { css, ts } from "better-tailwindcss:tests/utils/template.js";
+import { getTailwindCSSVersion } from "better-tailwindcss:tests/utils/version.js";
+
+
+describe(enforceMotionSafeVariant.name, () => {
+
+  it("should not report transition classes with the motion-safe variant", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="motion-safe:transition-colors" />`,
+          html: `<img class="motion-safe:transition-colors" />`,
+          jsx: `() => <img class="motion-safe:transition-colors" />`,
+          svelte: `<img class="motion-safe:transition-colors" />`,
+          vue: `<template><img class="motion-safe:transition-colors" /></template>`
+        },
+        {
+          angular: `<img class="motion-safe:transition" />`,
+          html: `<img class="motion-safe:transition" />`,
+          jsx: `() => <img class="motion-safe:transition" />`,
+          svelte: `<img class="motion-safe:transition" />`,
+          vue: `<template><img class="motion-safe:transition" /></template>`
+        },
+        {
+          angular: `<img class="motion-safe:transition-all" />`,
+          html: `<img class="motion-safe:transition-all" />`,
+          jsx: `() => <img class="motion-safe:transition-all" />`,
+          svelte: `<img class="motion-safe:transition-all" />`,
+          vue: `<template><img class="motion-safe:transition-all" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should not report animate classes with the motion-safe variant", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="motion-safe:animate-spin" />`,
+          html: `<img class="motion-safe:animate-spin" />`,
+          jsx: `() => <img class="motion-safe:animate-spin" />`,
+          svelte: `<img class="motion-safe:animate-spin" />`,
+          vue: `<template><img class="motion-safe:animate-spin" /></template>`
+        },
+        {
+          angular: `<img class="motion-safe:animate-none" />`,
+          html: `<img class="motion-safe:animate-none" />`,
+          jsx: `() => <img class="motion-safe:animate-none" />`,
+          svelte: `<img class="motion-safe:animate-none" />`,
+          vue: `<template><img class="motion-safe:animate-none" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should not report non-motion classes", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="text-red-500" />`,
+          html: `<img class="text-red-500" />`,
+          jsx: `() => <img class="text-red-500" />`,
+          svelte: `<img class="text-red-500" />`,
+          vue: `<template><img class="text-red-500" /></template>`
+        },
+        {
+          angular: `<img class="duration-300" />`,
+          html: `<img class="duration-300" />`,
+          jsx: `() => <img class="duration-300" />`,
+          svelte: `<img class="duration-300" />`,
+          vue: `<template><img class="duration-300" /></template>`
+        },
+        {
+          angular: `<img class="ease-in-out" />`,
+          html: `<img class="ease-in-out" />`,
+          jsx: `() => <img class="ease-in-out" />`,
+          svelte: `<img class="ease-in-out" />`,
+          vue: `<template><img class="ease-in-out" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report transition classes without the motion-safe variant", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="transition-colors" />`,
+          html: `<img class="transition-colors" />`,
+          jsx: `() => <img class="transition-colors" />`,
+          svelte: `<img class="transition-colors" />`,
+          vue: `<template><img class="transition-colors" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="transition" />`,
+          html: `<img class="transition" />`,
+          jsx: `() => <img class="transition" />`,
+          svelte: `<img class="transition" />`,
+          vue: `<template><img class="transition" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="transition-all" />`,
+          html: `<img class="transition-all" />`,
+          jsx: `() => <img class="transition-all" />`,
+          svelte: `<img class="transition-all" />`,
+          vue: `<template><img class="transition-all" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should report animate classes without the motion-safe variant", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="animate-spin" />`,
+          html: `<img class="animate-spin" />`,
+          jsx: `() => <img class="animate-spin" />`,
+          svelte: `<img class="animate-spin" />`,
+          vue: `<template><img class="animate-spin" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="animate-ping" />`,
+          html: `<img class="animate-ping" />`,
+          jsx: `() => <img class="animate-ping" />`,
+          svelte: `<img class="animate-ping" />`,
+          vue: `<template><img class="animate-ping" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should report transition classes with other variants but missing motion-safe", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="hover:transition-colors" />`,
+          html: `<img class="hover:transition-colors" />`,
+          jsx: `() => <img class="hover:transition-colors" />`,
+          svelte: `<img class="hover:transition-colors" />`,
+          vue: `<template><img class="hover:transition-colors" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="dark:animate-spin" />`,
+          html: `<img class="dark:animate-spin" />`,
+          jsx: `() => <img class="dark:animate-spin" />`,
+          svelte: `<img class="dark:animate-spin" />`,
+          vue: `<template><img class="dark:animate-spin" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
+  it("should report multiple motion classes in the same literal", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="transition-all animate-spin" />`,
+          html: `<img class="transition-all animate-spin" />`,
+          jsx: `() => <img class="transition-all animate-spin" />`,
+          svelte: `<img class="transition-all animate-spin" />`,
+          vue: `<template><img class="transition-all animate-spin" /></template>`,
+
+          errors: 2
+        }
+      ]
+    });
+  });
+
+  it("should suppress warnings when allowMotionReduce option is enabled and literal contains a motion-reduce class", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="motion-reduce:transition-none transition-all" />`,
+          html: `<img class="motion-reduce:transition-none transition-all" />`,
+          jsx: `() => <img class="motion-reduce:transition-none transition-all" />`,
+          svelte: `<img class="motion-reduce:transition-none transition-all" />`,
+          vue: `<template><img class="motion-reduce:transition-none transition-all" /></template>`,
+
+          options: [{ allowMotionReduce: true }]
+        },
+        {
+          angular: `<img class="motion-reduce:animate-none animate-spin" />`,
+          html: `<img class="motion-reduce:animate-none animate-spin" />`,
+          jsx: `() => <img class="motion-reduce:animate-none animate-spin" />`,
+          svelte: `<img class="motion-reduce:animate-none animate-spin" />`,
+          vue: `<template><img class="motion-reduce:animate-none animate-spin" /></template>`,
+
+          options: [{ allowMotionReduce: true }]
+        }
+      ]
+    });
+  });
+
+  it("should still report when allowMotionReduce option is enabled but no motion-reduce class is present", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="transition-all" />`,
+          html: `<img class="transition-all" />`,
+          jsx: `() => <img class="transition-all" />`,
+          svelte: `<img class="transition-all" />`,
+          vue: `<template><img class="transition-all" /></template>`,
+
+          errors: 1,
+
+          options: [{ allowMotionReduce: true }]
+        }
+      ]
+    });
+  });
+
+  it("should not report transition classes when custom patterns are set and do not include transition", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="transition-all" />`,
+          html: `<img class="transition-all" />`,
+          jsx: `() => <img class="transition-all" />`,
+          svelte: `<img class="transition-all" />`,
+          vue: `<template><img class="transition-all" /></template>`,
+
+          options: [{ classes: ["^my-animation$"] }]
+        }
+      ]
+    });
+  });
+
+  it("should work in combination with other variants", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="dark:motion-safe:transition-colors" />`,
+          html: `<img class="dark:motion-safe:transition-colors" />`,
+          jsx: `() => <img class="dark:motion-safe:transition-colors" />`,
+          svelte: `<img class="dark:motion-safe:transition-colors" />`,
+          vue: `<template><img class="dark:motion-safe:transition-colors" /></template>`
+        },
+        {
+          angular: `<img class="motion-safe:hover:animate-spin" />`,
+          html: `<img class="motion-safe:hover:animate-spin" />`,
+          jsx: `() => <img class="motion-safe:hover:animate-spin" />`,
+          svelte: `<img class="motion-safe:hover:animate-spin" />`,
+          vue: `<template><img class="motion-safe:hover:animate-spin" /></template>`
+        },
+        {
+          angular: `<img class="lg:dark:motion-safe:transition-all" />`,
+          html: `<img class="lg:dark:motion-safe:transition-all" />`,
+          jsx: `() => <img class="lg:dark:motion-safe:transition-all" />`,
+          svelte: `<img class="lg:dark:motion-safe:transition-all" />`,
+          vue: `<template><img class="lg:dark:motion-safe:transition-all" /></template>`
+        }
+      ]
+    });
+  });
+
+  it.runIf(getTailwindCSSVersion().major <= 3)("should still work with a prefixed tailwind config in tailwind <= 3", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="tw-transition-colors" />`,
+          html: `<img class="tw-transition-colors" />`,
+          jsx: `() => <img class="tw-transition-colors" />`,
+          svelte: `<img class="tw-transition-colors" />`,
+          vue: `<template><img class="tw-transition-colors" /></template>`,
+
+          errors: 1,
+
+          files: {
+            "tailwind.config.prefix.js": ts`
+              export default {
+                prefix: 'tw-',
+              };
+            `
+          },
+          options: [{ tailwindConfig: "./tailwind.config.prefix.js" }]
+        }
+      ],
+      valid: [
+        {
+          angular: `<img class="tw-motion-safe:tw-transition-colors" />`,
+          html: `<img class="tw-motion-safe:tw-transition-colors" />`,
+          jsx: `() => <img class="tw-motion-safe:tw-transition-colors" />`,
+          svelte: `<img class="tw-motion-safe:tw-transition-colors" />`,
+          vue: `<template><img class="tw-motion-safe:tw-transition-colors" /></template>`,
+
+          files: {
+            "tailwind.config.prefix.js": ts`
+              export default {
+                prefix: 'tw-',
+              };
+            `
+          },
+          options: [{ tailwindConfig: "./tailwind.config.prefix.js" }]
+        }
+      ]
+    });
+  });
+
+  it.runIf(getTailwindCSSVersion().major >= 4)("should still work with a prefixed tailwind config in tailwind >= 4", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="tw:transition-colors" />`,
+          html: `<img class="tw:transition-colors" />`,
+          jsx: `() => <img class="tw:transition-colors" />`,
+          svelte: `<img class="tw:transition-colors" />`,
+          vue: `<template><img class="tw:transition-colors" /></template>`,
+
+          errors: 1,
+
+          files: {
+            "tailwind.css": css`
+              @import "tailwindcss" prefix(tw);
+            `
+          },
+          options: [{ entryPoint: "./tailwind.css" }]
+        }
+      ],
+      valid: [
+        {
+          angular: `<img class="tw:motion-safe:transition-colors" />`,
+          html: `<img class="tw:motion-safe:transition-colors" />`,
+          jsx: `() => <img class="tw:motion-safe:transition-colors" />`,
+          svelte: `<img class="tw:motion-safe:transition-colors" />`,
+          vue: `<template><img class="tw:motion-safe:transition-colors" /></template>`,
+
+          files: {
+            "tailwind.css": css`
+              @import "tailwindcss" prefix(tw);
+            `
+          },
+          options: [{ entryPoint: "./tailwind.css" }]
+        }
+      ]
+    });
+  });
+
+  it("should suppress warnings via allowMotionReduce option when motion-reduce class is in priorLiterals", () => {
+    const expression = "${true ? 'foo' : 'bar'}";
+
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          jsx: `() => <img class={\`motion-reduce:transition-none ${expression} transition-all\`} />`,
+          svelte: `<img class={\`motion-reduce:transition-none ${expression} transition-all\`} />`,
+
+          options: [{ allowMotionReduce: true }]
+        }
+      ]
+    });
+  });
+
+});

--- a/src/rules/enforce-motion-safe-variant.test.ts
+++ b/src/rules/enforce-motion-safe-variant.test.ts
@@ -296,11 +296,11 @@ describe(enforceMotionSafeVariant.name, () => {
       ],
       valid: [
         {
-          angular: `<img class="tw-motion-safe:tw-transition-colors" />`,
-          html: `<img class="tw-motion-safe:tw-transition-colors" />`,
-          jsx: `() => <img class="tw-motion-safe:tw-transition-colors" />`,
-          svelte: `<img class="tw-motion-safe:tw-transition-colors" />`,
-          vue: `<template><img class="tw-motion-safe:tw-transition-colors" /></template>`,
+          angular: `<img class="motion-safe:tw-transition-colors" />`,
+          html: `<img class="motion-safe:tw-transition-colors" />`,
+          jsx: `() => <img class="motion-safe:tw-transition-colors" />`,
+          svelte: `<img class="motion-safe:tw-transition-colors" />`,
+          vue: `<template><img class="motion-safe:tw-transition-colors" /></template>`,
 
           files: {
             "tailwind.config.prefix.js": ts`

--- a/src/rules/enforce-motion-safe-variant.test.ts
+++ b/src/rules/enforce-motion-safe-variant.test.ts
@@ -369,4 +369,192 @@ describe(enforceMotionSafeVariant.name, () => {
     });
   });
 
+  it("should still report when motion-reduce exists but allowMotionReduce is disabled", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="motion-reduce:transition-none transition-all" />`,
+          html: `<img class="motion-reduce:transition-none transition-all" />`,
+          jsx: `() => <img class="motion-reduce:transition-none transition-all" />`,
+          svelte: `<img class="motion-reduce:transition-none transition-all" />`,
+          vue: `<template><img class="motion-reduce:transition-none transition-all" /></template>`,
+
+          errors: 1,
+
+          options: [{ allowMotionReduce: false }]
+        }
+      ]
+    });
+  });
+
+  it("should never report classes that already use the motion-reduce variant", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="motion-reduce:transition-none" />`,
+          html: `<img class="motion-reduce:transition-none" />`,
+          jsx: `() => <img class="motion-reduce:transition-none" />`,
+          svelte: `<img class="motion-reduce:transition-none" />`,
+          vue: `<template><img class="motion-reduce:transition-none" /></template>`
+        },
+        {
+          angular: `<img class="motion-reduce:animate-none" />`,
+          html: `<img class="motion-reduce:animate-none" />`,
+          jsx: `() => <img class="motion-reduce:animate-none" />`,
+          svelte: `<img class="motion-reduce:animate-none" />`,
+          vue: `<template><img class="motion-reduce:animate-none" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should suppress regardless of class order when allowMotionReduce is enabled", () => {
+    lint(enforceMotionSafeVariant, {
+      valid: [
+        {
+          angular: `<img class="transition-all motion-reduce:transition-none" />`,
+          html: `<img class="transition-all motion-reduce:transition-none" />`,
+          jsx: `() => <img class="transition-all motion-reduce:transition-none" />`,
+          svelte: `<img class="transition-all motion-reduce:transition-none" />`,
+          vue: `<template><img class="transition-all motion-reduce:transition-none" /></template>`,
+
+          options: [{ allowMotionReduce: true }]
+        }
+      ]
+    });
+  });
+
+  it("should report motion classes from priorLiterals when allowMotionReduce is disabled", () => {
+    const expression = "${true ? 'foo' : 'bar'}";
+
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          jsx: `() => <img class={\`motion-reduce:transition-none ${expression} transition-all\`} />`,
+          svelte: `<img class={\`motion-reduce:transition-none ${expression} transition-all\`} />`,
+
+          errors: 1,
+
+          options: [{ allowMotionReduce: false }]
+        }
+      ]
+    });
+  });
+
+  it("should report arbitrary value transition and animate classes without motion-safe", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="transition-[opacity]" />`,
+          html: `<img class="transition-[opacity]" />`,
+          jsx: `() => <img class="transition-[opacity]" />`,
+          svelte: `<img class="transition-[opacity]" />`,
+          vue: `<template><img class="transition-[opacity]" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="animate-[spin_1s_linear_infinite]" />`,
+          html: `<img class="animate-[spin_1s_linear_infinite]" />`,
+          jsx: `() => <img class="animate-[spin_1s_linear_infinite]" />`,
+          svelte: `<img class="animate-[spin_1s_linear_infinite]" />`,
+          vue: `<template><img class="animate-[spin_1s_linear_infinite]" /></template>`,
+
+          errors: 1
+        }
+      ],
+      valid: [
+        {
+          angular: `<img class="motion-safe:transition-[opacity]" />`,
+          html: `<img class="motion-safe:transition-[opacity]" />`,
+          jsx: `() => <img class="motion-safe:transition-[opacity]" />`,
+          svelte: `<img class="motion-safe:transition-[opacity]" />`,
+          vue: `<template><img class="motion-safe:transition-[opacity]" /></template>`
+        },
+        {
+          angular: `<img class="motion-safe:animate-[spin_1s_linear_infinite]" />`,
+          html: `<img class="motion-safe:animate-[spin_1s_linear_infinite]" />`,
+          jsx: `() => <img class="motion-safe:animate-[spin_1s_linear_infinite]" />`,
+          svelte: `<img class="motion-safe:animate-[spin_1s_linear_infinite]" />`,
+          vue: `<template><img class="motion-safe:animate-[spin_1s_linear_infinite]" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report important motion classes without motion-safe", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="!transition-all" />`,
+          html: `<img class="!transition-all" />`,
+          jsx: `() => <img class="!transition-all" />`,
+          svelte: `<img class="!transition-all" />`,
+          vue: `<template><img class="!transition-all" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="transition-all!" />`,
+          html: `<img class="transition-all!" />`,
+          jsx: `() => <img class="transition-all!" />`,
+          svelte: `<img class="transition-all!" />`,
+          vue: `<template><img class="transition-all!" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="!animate-spin" />`,
+          html: `<img class="!animate-spin" />`,
+          jsx: `() => <img class="!animate-spin" />`,
+          svelte: `<img class="!animate-spin" />`,
+          vue: `<template><img class="!animate-spin" /></template>`,
+
+          errors: 1
+        },
+        {
+          angular: `<img class="animate-spin!" />`,
+          html: `<img class="animate-spin!" />`,
+          jsx: `() => <img class="animate-spin!" />`,
+          svelte: `<img class="animate-spin!" />`,
+          vue: `<template><img class="animate-spin!" /></template>`,
+
+          errors: 1
+        }
+      ],
+      valid: [
+        {
+          angular: `<img class="motion-safe:!transition-all" />`,
+          html: `<img class="motion-safe:!transition-all" />`,
+          jsx: `() => <img class="motion-safe:!transition-all" />`,
+          svelte: `<img class="motion-safe:!transition-all" />`,
+          vue: `<template><img class="motion-safe:!transition-all" /></template>`
+        },
+        {
+          angular: `<img class="motion-safe:transition-all!" />`,
+          html: `<img class="motion-safe:transition-all!" />`,
+          jsx: `() => <img class="motion-safe:transition-all!" />`,
+          svelte: `<img class="motion-safe:transition-all!" />`,
+          vue: `<template><img class="motion-safe:transition-all!" /></template>`
+        }
+      ]
+    });
+  });
+
+  it("should report duplicate offending classes deterministically", () => {
+    lint(enforceMotionSafeVariant, {
+      invalid: [
+        {
+          angular: `<img class="transition-all transition-all" />`,
+          html: `<img class="transition-all transition-all" />`,
+          jsx: `() => <img class="transition-all transition-all" />`,
+          svelte: `<img class="transition-all transition-all" />`,
+          vue: `<template><img class="transition-all transition-all" /></template>`,
+
+          errors: 2
+        }
+      ]
+    });
+  });
+
 });

--- a/src/rules/enforce-motion-safe-variant.ts
+++ b/src/rules/enforce-motion-safe-variant.ts
@@ -1,0 +1,127 @@
+import {
+  array,
+  boolean,
+  description,
+  optional,
+  pipe,
+  strictObject,
+  string
+} from "valibot";
+
+import { createGetDissectedClasses, getDissectedClasses } from "better-tailwindcss:tailwindcss/dissect-classes.js";
+import { async } from "better-tailwindcss:utils/context.js";
+import { lintClasses } from "better-tailwindcss:utils/lint.js";
+import { getCachedRegex } from "better-tailwindcss:utils/regex.js";
+import { createRule } from "better-tailwindcss:utils/rule.js";
+import { splitClasses } from "better-tailwindcss:utils/utils.js";
+
+import type { Literal } from "better-tailwindcss:types/ast.js";
+import type { Context } from "better-tailwindcss:types/rule.js";
+
+
+export const enforceMotionSafeVariant = createRule({
+  autofix: false,
+  category: "correctness",
+  description: "Enforce the 'motion-safe' variant for transition and animation classes.",
+  docs: "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-motion-safe-variant.md",
+  name: "enforce-motion-safe-variant",
+  recommended: false,
+
+  messages: {
+    missing: "{{ className }} is missing the 'motion-safe' variant."
+  },
+
+  schema: strictObject({
+    allowMotionReduce: optional(
+      pipe(
+        boolean(),
+        description("Suppress warnings for a literal that already contains a class with the 'motion-reduce' variant (in itself or in prior literals).")
+      ),
+      false
+    ),
+    classes: optional(
+      pipe(
+        array(string()),
+        description("A list of regular expression patterns for classes that require the 'motion-safe' variant.")
+      ),
+      ["^transition(-.*)?$", "^animate(-.*)?$"]
+    )
+  }),
+
+  initialize: ctx => {
+    createGetDissectedClasses(ctx);
+  },
+
+  lintLiterals: (ctx, literals) => lintLiterals(ctx, literals)
+});
+
+
+function lintLiterals(ctx: Context<typeof enforceMotionSafeVariant>, literals: Literal[]) {
+  const { allowMotionReduce, classes: classPatterns } = ctx.options;
+
+  for(const literal of literals){
+    const classes = splitClasses(literal.content);
+    const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+
+    if(allowMotionReduce && hasMotionReduceVariant(ctx, literal, dissectedClasses)){
+      continue;
+    }
+
+    lintClasses(ctx, literal, className => {
+      const dissectedClass = dissectedClasses[className];
+
+      if(dissectedClass?.variants === undefined){
+        return;
+      }
+
+      if(!classPatterns.some(pattern => getCachedRegex(pattern).test(dissectedClass.base))){
+        return;
+      }
+
+      if(dissectedClass.variants.includes("motion-safe") || dissectedClass.variants.includes("motion-reduce")){
+        return;
+      }
+
+      return {
+        data: { className },
+        id: "missing",
+        warnings
+      } as const;
+    });
+  }
+}
+
+function hasMotionReduceVariant(
+  ctx: Context<typeof enforceMotionSafeVariant>,
+  literal: Literal,
+  dissectedClasses: ReturnType<typeof getDissectedClasses>["dissectedClasses"]
+): boolean {
+  if(hasMotionReduceInClasses(dissectedClasses)){
+    return true;
+  }
+
+  if(!literal.priorLiterals){
+    return false;
+  }
+
+  for(const priorLiteral of literal.priorLiterals){
+    if(!priorLiteral){ continue; }
+
+    const priorClasses = splitClasses(priorLiteral.content);
+    const { dissectedClasses: priorDissectedClasses } = getDissectedClasses(async(ctx), priorClasses);
+
+    if(hasMotionReduceInClasses(priorDissectedClasses)){
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasMotionReduceInClasses(
+  dissectedClasses: ReturnType<typeof getDissectedClasses>["dissectedClasses"]
+): boolean {
+  return Object.values(dissectedClasses).some(
+    dissectedClass => dissectedClass.variants?.includes("motion-reduce")
+  );
+}


### PR DESCRIPTION
Introduces a new ESLint rule that enforces the `motion-safe` variant for transition and animation classes.

Users who prefer reduced motion in their browser or OS settings expect animations to respect their preferences. This rule ensures that all motion-related CSS classes are properly wrapped with the `motion-safe` variant, so animations only apply when safe to do so.

Supports both Tailwind CSS v3 and v4.

- `allowMotionReduce` (boolean, default: `false`) - Suppress warnings if `motion-reduce` is used as an alternative
- `classes` (string[], default: `["^transition(-.*)?$", "^animate(-.*)?$"]`) - Customize which classes require the variant

```tsx
<div class="transition-colors"></div>
            ~~~~~~~~~~~~~~~~~
<div class="motion-safe:transition-colors"></div>
<div class="motion-reduce:transition-none transition-all"></div>
```